### PR TITLE
Feature/overview batch links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D22-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
-[![Tests](https://img.shields.io/badge/tests-318%20passed-brightgreen?logo=vitest&logoColor=white)](#-testing)
+[![Tests](https://img.shields.io/badge/tests-342%20passed-brightgreen?logo=vitest&logoColor=white)](#-testing)
 
 </div>
 
@@ -59,6 +59,9 @@
 | 🏷️ | **Frontmatter management** | AST-based read and update of YAML frontmatter — safely manage tags, statuses, and metadata without corrupting file structure |
 | 👀 | **Dry-run / diff preview** | Preview any edit operation as a unified diff without saving — set `dryRun=true` on any edit action |
 | 📝 | **Templating / scaffolding** | Create new notes from template files with `{{variable}}` placeholder injection — refuses to overwrite existing files |
+| 🗺️ | **Vault overview** | Structural map of the vault — total file count, recursive folder tree with file counts and last modification dates per folder |
+| 📦 | **Batch edit** | Apply multiple edit operations in a single call — sequential execution, stops on first error, supports `dryRun`, max 50 ops |
+| 🔗 | **Backlinks index** | Find all notes linking to a given path — supports wikilinks and markdown links with line numbers and context snippets |
 | 🎯 | **Typo resilience** | Levenshtein-based fuzzy matching for edit operations |
 
 ---
@@ -68,10 +71,10 @@
 | Tool | Actions | Description |
 |---|---|---|
 | 📁 **vault** | `list` `read` `create` `update` `delete` `stat` `create_from_template` | Full CRUD for vault notes + template scaffolding |
-| ✏️ **edit** | `append` `prepend` `replace` `line_replace` `string_replace` `frontmatter_set` | AST-based patching + freeform fallback + frontmatter update (supports `dryRun` diff preview) |
-| 👁️ **view** | `search` `global_search` `semantic_search` `outline` `read` `frontmatter_get` `bulk_read` | Fragment retrieval, cross-vault search, hybrid semantic search, read by heading, frontmatter read, bulk read |
+| ✏️ **edit** | `append` `prepend` `replace` `line_replace` `string_replace` `frontmatter_set` `batch` | AST-based patching + freeform fallback + frontmatter update + batch edit (supports `dryRun` diff preview) |
+| 👁️ **view** | `search` `global_search` `semantic_search` `outline` `read` `frontmatter_get` `bulk_read` `backlinks` | Fragment retrieval, cross-vault search, hybrid semantic search, read by heading, frontmatter read, bulk read, backlinks |
 | 🔄 **workflow** | `status` `transition` `history` `reset` | Petri net state machine control |
-| ⚙️ **system** | `status` `reindex` | Server health and indexing info |
+| ⚙️ **system** | `status` `reindex` `overview` | Server health, indexing info, vault structure overview |
 
 > All tool responses include contextual hints based on the current workflow state.
 

--- a/src/domain/errors/index.ts
+++ b/src/domain/errors/index.ts
@@ -113,6 +113,18 @@ export class InvalidFrontmatterPayloadError extends DomainError {
   }
 }
 
+// ── Batch errors ─────────────────────────────────────────────────
+
+export class BatchLimitExceededError extends DomainError {
+  constructor(count: number, limit: number) {
+    super(
+      "BATCH_LIMIT_EXCEEDED",
+      `Batch limit exceeded: ${count} operations requested, max ${limit} allowed`,
+    );
+    this.name = "BatchLimitExceededError";
+  }
+}
+
 // ── Workflow / State errors ────────────────────────────────────────
 
 export class StateTransitionError extends DomainError {

--- a/src/domain/interfaces/backlink-index.ts
+++ b/src/domain/interfaces/backlink-index.ts
@@ -1,0 +1,19 @@
+/** Wpis backlinku — informacja o jednym linku prowadzącym do pliku docelowego. */
+export interface BacklinkEntry {
+  sourcePath: string;
+  lineNumber: number;
+  context: string;
+  linkType: "wikilink" | "markdown_link";
+}
+
+/** Port dla indeksu backlinków. */
+export interface IBacklinkIndex {
+  /** Zwraca backlinki prowadzące do podanej ścieżki docelowej. */
+  getBacklinks(targetPath: string): BacklinkEntry[];
+
+  /** Przebudowuje cały indeks z podanych plików. */
+  rebuildIndex(entries: Array<{ path: string; content: string }>): void;
+
+  /** Aktualizuje indeks dla pojedynczego pliku (usuwa stare wpisy i dodaje nowe). */
+  updateFile(path: string, content: string): void;
+}

--- a/src/domain/interfaces/backlink-index.ts
+++ b/src/domain/interfaces/backlink-index.ts
@@ -1,4 +1,4 @@
-/** Wpis backlinku — informacja o jednym linku prowadzącym do pliku docelowego. */
+/** Backlink entry — information about a single link pointing to a target file. */
 export interface BacklinkEntry {
   sourcePath: string;
   lineNumber: number;
@@ -6,17 +6,17 @@ export interface BacklinkEntry {
   linkType: "wikilink" | "markdown_link";
 }
 
-/** Port dla indeksu backlinków. */
+/** Port for the backlink index. */
 export interface IBacklinkIndex {
-  /** Zwraca backlinki prowadzące do podanej ścieżki docelowej. */
+  /** Returns backlinks pointing to the given target path. */
   getBacklinks(targetPath: string): BacklinkEntry[];
 
-  /** Przebudowuje cały indeks z podanych plików. */
+  /** Rebuilds the entire index from the given files. */
   rebuildIndex(entries: Array<{ path: string; content: string }>): void;
 
-  /** Aktualizuje indeks dla pojedynczego pliku (usuwa stare wpisy i dodaje nowe). */
+  /** Updates the index for a single file (removes old entries and adds new ones). */
   updateFile(path: string, content: string): void;
 
-  /** Usuwa wszystkie wpisy backlinków gdzie plik jest źródłem linku. */
+  /** Removes all backlink entries where the file is a link source. */
   removeFile(path: string): void;
 }

--- a/src/domain/interfaces/backlink-index.ts
+++ b/src/domain/interfaces/backlink-index.ts
@@ -16,4 +16,7 @@ export interface IBacklinkIndex {
 
   /** Aktualizuje indeks dla pojedynczego pliku (usuwa stare wpisy i dodaje nowe). */
   updateFile(path: string, content: string): void;
+
+  /** Usuwa wszystkie wpisy backlinków gdzie plik jest źródłem linku. */
+  removeFile(path: string): void;
 }

--- a/src/domain/interfaces/index.ts
+++ b/src/domain/interfaces/index.ts
@@ -9,3 +9,9 @@ export type {
 export type { IMarkdownRepository } from "./markdown-repository.js";
 export type { IDiffService } from "./diff-service.js";
 export type { ITemplateEngine } from "./template-engine.js";
+export type {
+  IVaultOverviewService,
+  VaultOverview,
+  FolderSummary,
+} from "./vault-overview-service.js";
+export type { IBacklinkIndex, BacklinkEntry } from "./backlink-index.js";

--- a/src/domain/interfaces/vault-overview-service.ts
+++ b/src/domain/interfaces/vault-overview-service.ts
@@ -1,4 +1,4 @@
-/** Podsumowanie pojedynczego katalogu w vault. */
+/** Summary of a single directory in the vault. */
 export interface FolderSummary {
   path: string;
   fileCount: number;
@@ -6,13 +6,13 @@ export interface FolderSummary {
   children: FolderSummary[];
 }
 
-/** Przegląd struktury vault. */
+/** Overview of the vault structure. */
 export interface VaultOverview {
   totalFiles: number;
   folders: FolderSummary[];
 }
 
-/** Port dla usługi przeglądu vault. */
+/** Port for the vault overview service. */
 export interface IVaultOverviewService {
   getOverview(maxDepth?: number): Promise<VaultOverview>;
 }

--- a/src/domain/interfaces/vault-overview-service.ts
+++ b/src/domain/interfaces/vault-overview-service.ts
@@ -1,0 +1,18 @@
+/** Podsumowanie pojedynczego katalogu w vault. */
+export interface FolderSummary {
+  path: string;
+  fileCount: number;
+  lastModified: string;
+  children: FolderSummary[];
+}
+
+/** Przegląd struktury vault. */
+export interface VaultOverview {
+  totalFiles: number;
+  folders: FolderSummary[];
+}
+
+/** Port dla usługi przeglądu vault. */
+export interface IVaultOverviewService {
+  getOverview(maxDepth?: number): Promise<VaultOverview>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,8 +75,19 @@ async function main(): Promise<void> {
   // Indeks backlinków — współdzielony między połączeniami
   const backlinkIndex = new BacklinkIndexService(new MarkdownPipeline());
 
+  // Start background indexing (shared across all connections)
+  const indexer = new VaultIndexer(vaultRoot, vectorStore, embedder);
+
+  // Podłącz callbacki watchera do indeksu backlinków
+  indexer.setOnFileIndexed((relPath, content) => {
+    backlinkIndex.updateFile(relPath, content);
+  });
+  indexer.setOnFileRemoved((relPath) => {
+    backlinkIndex.removeFile(relPath);
+  });
+
   // Server factory: each connection gets its own McpServer + WorkflowStateMachine.
-  // Shared deps (fs, vectors, embedder, backlinkIndex) are captured by closure.
+  // Shared deps (fs, vectors, embedder, backlinkIndex, indexer) are captured by closure.
   const serverFactory = () =>
     createMcpServer({
       fsAdapter,
@@ -85,10 +96,8 @@ async function main(): Promise<void> {
       workflow: new WorkflowStateMachine(),
       vaultRoot,
       backlinkIndex,
+      indexer,
     });
-
-  // Start background indexing (shared across all connections)
-  const indexer = new VaultIndexer(vaultRoot, vectorStore, embedder);
 
   // Indeksowanie wektorowe + backlinki na starcie
   indexer

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import { TransformersEmbeddingProvider } from "./infrastructure/transformers-emb
 import type { IEmbeddingProvider } from "./domain/interfaces/index.js";
 import { WorkflowStateMachine } from "./use-cases/workflow-state.js";
 import { VaultIndexer } from "./use-cases/vault-indexer.js";
+import { BacklinkIndexService } from "./use-cases/backlink-index.js";
+import { MarkdownPipeline } from "./use-cases/markdown-pipeline.js";
 import { createMcpServer } from "./presentation/mcp-tools.js";
 import {
   parseTransportType,
@@ -65,13 +67,16 @@ async function main(): Promise<void> {
   );
   const port = parseInt(process.env["PORT"] ?? "3000", 10);
 
-  // Shared dependencies (reused across all client connections)
+  // Współdzielone zależności (reużywane przez wszystkie połączenia klientów)
   const fsAdapter = await LocalFileSystemAdapter.create(vaultRoot);
   const vectorStore = new InMemoryVectorStore();
   const embedder = await createEmbeddingProvider();
 
+  // Indeks backlinków — współdzielony między połączeniami
+  const backlinkIndex = new BacklinkIndexService(new MarkdownPipeline());
+
   // Server factory: each connection gets its own McpServer + WorkflowStateMachine.
-  // Shared deps (fs, vectors, embedder) are captured by closure.
+  // Shared deps (fs, vectors, embedder, backlinkIndex) are captured by closure.
   const serverFactory = () =>
     createMcpServer({
       fsAdapter,
@@ -79,12 +84,27 @@ async function main(): Promise<void> {
       embedder,
       workflow: new WorkflowStateMachine(),
       vaultRoot,
+      backlinkIndex,
     });
 
   // Start background indexing (shared across all connections)
   const indexer = new VaultIndexer(vaultRoot, vectorStore, embedder);
+
+  // Indeksowanie wektorowe + backlinki na starcie
   indexer
     .indexAll()
+    .then(async () => {
+      // Zbuduj indeks backlinków po zaindeksowaniu vault
+      const allFiles = await fsAdapter.listNotes();
+      const entries = await Promise.all(
+        allFiles.map(async (p) => ({
+          path: p,
+          content: await fsAdapter.readNote(p),
+        })),
+      );
+      backlinkIndex.rebuildIndex(entries);
+      console.error(`Backlink index built: ${allFiles.length} files`);
+    })
     .catch((err: unknown) =>
       console.error("Initial indexing failed:", err),
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,18 +67,18 @@ async function main(): Promise<void> {
   );
   const port = parseInt(process.env["PORT"] ?? "3000", 10);
 
-  // Współdzielone zależności (reużywane przez wszystkie połączenia klientów)
+  // Shared dependencies (reused across all client connections)
   const fsAdapter = await LocalFileSystemAdapter.create(vaultRoot);
   const vectorStore = new InMemoryVectorStore();
   const embedder = await createEmbeddingProvider();
 
-  // Indeks backlinków — współdzielony między połączeniami
+  // Backlink index — shared across connections
   const backlinkIndex = new BacklinkIndexService(new MarkdownPipeline());
 
   // Start background indexing (shared across all connections)
   const indexer = new VaultIndexer(vaultRoot, vectorStore, embedder);
 
-  // Podłącz callbacki watchera do indeksu backlinków
+  // Wire watcher callbacks to backlink index
   indexer.setOnFileIndexed((relPath, content) => {
     backlinkIndex.updateFile(relPath, content);
   });
@@ -99,11 +99,11 @@ async function main(): Promise<void> {
       indexer,
     });
 
-  // Indeksowanie wektorowe + backlinki na starcie
+  // Vector indexing + backlinks on startup
   indexer
     .indexAll()
     .then(async () => {
-      // Zbuduj indeks backlinków po zaindeksowaniu vault
+      // Build backlink index after vault indexing completes
       const allFiles = await fsAdapter.listNotes();
       const entries = await Promise.all(
         allFiles.map(async (p) => ({

--- a/src/presentation/mcp-tools.test.ts
+++ b/src/presentation/mcp-tools.test.ts
@@ -400,10 +400,127 @@ describe("workflow tool", () => {
   });
 });
 
+// ── backlink live updates ─────────────────────────────────────────
+
+describe("backlink index — live updates via MCP operations", () => {
+  it("vault.create aktualizuje indeks backlinków", async () => {
+    await client.callTool({
+      name: "vault",
+      arguments: {
+        action: "create",
+        path: "linker.md",
+        content: "# Linker\n\nSee [[hello]].\n",
+      },
+    });
+
+    const result = await client.callTool({
+      name: "view",
+      arguments: { action: "backlinks", path: "hello.md" },
+    });
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0]!.text);
+
+    // daily/2024-01-01.md (z beforeEach) + linker.md (nowo utworzony)
+    expect(parsed.result.count).toBe(2);
+    const sources = parsed.result.backlinks.map((b: { sourcePath: string }) => b.sourcePath).sort();
+    expect(sources).toContain("linker.md");
+  });
+
+  it("vault.delete usuwa wpisy backlinków z tego źródła", async () => {
+    // Najpierw upewnij się, że daily/2024-01-01.md jest źródłem backlinku
+    const before = await client.callTool({
+      name: "view",
+      arguments: { action: "backlinks", path: "hello.md" },
+    });
+    const beforeParsed = JSON.parse((before.content as Array<{ type: string; text: string }>)[0]!.text);
+    expect(beforeParsed.result.count).toBe(1);
+
+    // Usuń plik będący źródłem linku
+    await client.callTool({
+      name: "vault",
+      arguments: { action: "delete", path: "daily/2024-01-01.md" },
+    });
+
+    const after = await client.callTool({
+      name: "view",
+      arguments: { action: "backlinks", path: "hello.md" },
+    });
+    const afterParsed = JSON.parse((after.content as Array<{ type: string; text: string }>)[0]!.text);
+    expect(afterParsed.result.count).toBe(0);
+  });
+
+  it("edit.string_replace aktualizuje indeks backlinków", async () => {
+    // Utwórz cel linkowania
+    await client.callTool({
+      name: "vault",
+      arguments: {
+        action: "create",
+        path: "target.md",
+        content: "# Target\n",
+      },
+    });
+
+    // Zamień tekst dodając link (string_replace nie przechodzi przez AST, więc zachowuje wikilinki)
+    const editResult = await client.callTool({
+      name: "edit",
+      arguments: {
+        path: "hello.md",
+        operation: "string_replace",
+        searchText: "Welcome to the vault.",
+        content: "Welcome to the vault. See [[target]].",
+      },
+    });
+    expect(editResult.isError).toBeFalsy();
+
+    const result = await client.callTool({
+      name: "view",
+      arguments: { action: "backlinks", path: "target.md" },
+    });
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0]!.text);
+    expect(parsed.result.count).toBe(1);
+    expect(parsed.result.backlinks[0].sourcePath).toBe("hello.md");
+  });
+
+  it("pełna sekwencja: create → backlinks → delete → backlinks", async () => {
+    // 1. Utwórz cel
+    await client.callTool({
+      name: "vault",
+      arguments: { action: "create", path: "target.md", content: "# Target\n" },
+    });
+
+    // 2. Utwórz plik linkujący
+    await client.callTool({
+      name: "vault",
+      arguments: { action: "create", path: "linker.md", content: "See [[target]]\n" },
+    });
+
+    // 3. Sprawdź backlinki — powinien być 1
+    const mid = await client.callTool({
+      name: "view",
+      arguments: { action: "backlinks", path: "target.md" },
+    });
+    const midParsed = JSON.parse((mid.content as Array<{ type: string; text: string }>)[0]!.text);
+    expect(midParsed.result.count).toBe(1);
+
+    // 4. Usuń plik linkujący
+    await client.callTool({
+      name: "vault",
+      arguments: { action: "delete", path: "linker.md" },
+    });
+
+    // 5. Sprawdź backlinki — powinien być 0
+    const end = await client.callTool({
+      name: "view",
+      arguments: { action: "backlinks", path: "target.md" },
+    });
+    const endParsed = JSON.parse((end.content as Array<{ type: string; text: string }>)[0]!.text);
+    expect(endParsed.result.count).toBe(0);
+  });
+});
+
 // ── system tool ───────────────────────────────────────────────────
 
 describe("system tool", () => {
-  it("returns system status", async () => {
+  it("returns system status with backlinkIndexSize", async () => {
     const result = await client.callTool({
       name: "system",
       arguments: { action: "status" },
@@ -412,6 +529,8 @@ describe("system tool", () => {
     const parsed = JSON.parse(content[0]!.text);
     expect(parsed.result.vaultRoot).toBe(tmpDir);
     expect(typeof parsed.result.indexedDocuments).toBe("number");
+    expect(typeof parsed.result.backlinkIndexSize).toBe("number");
+    expect(parsed.result.backlinkIndexSize).toBeGreaterThan(0);
   });
 
   it("returns vault overview with folder structure", async () => {

--- a/src/presentation/mcp-tools.test.ts
+++ b/src/presentation/mcp-tools.test.ts
@@ -51,7 +51,7 @@ beforeEach(async () => {
   const embedder = new FakeEmbedder();
   const workflow = new WorkflowStateMachine();
 
-  // Indeks backlinków
+  // Backlink index
   const backlinkPipeline = new MarkdownPipeline();
   const backlinkIndex = new BacklinkIndexService(backlinkPipeline);
   backlinkIndex.rebuildIndex([
@@ -403,7 +403,7 @@ describe("workflow tool", () => {
 // ── backlink live updates ─────────────────────────────────────────
 
 describe("backlink index — live updates via MCP operations", () => {
-  it("vault.create aktualizuje indeks backlinków", async () => {
+  it("vault.create updates backlink index", async () => {
     await client.callTool({
       name: "vault",
       arguments: {
@@ -419,14 +419,14 @@ describe("backlink index — live updates via MCP operations", () => {
     });
     const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0]!.text);
 
-    // daily/2024-01-01.md (z beforeEach) + linker.md (nowo utworzony)
+    // daily/2024-01-01.md (from beforeEach) + linker.md (newly created)
     expect(parsed.result.count).toBe(2);
     const sources = parsed.result.backlinks.map((b: { sourcePath: string }) => b.sourcePath).sort();
     expect(sources).toContain("linker.md");
   });
 
-  it("vault.delete usuwa wpisy backlinków z tego źródła", async () => {
-    // Najpierw upewnij się, że daily/2024-01-01.md jest źródłem backlinku
+  it("vault.delete removes backlink entries from that source", async () => {
+    // First verify that daily/2024-01-01.md is a backlink source
     const before = await client.callTool({
       name: "view",
       arguments: { action: "backlinks", path: "hello.md" },
@@ -434,7 +434,7 @@ describe("backlink index — live updates via MCP operations", () => {
     const beforeParsed = JSON.parse((before.content as Array<{ type: string; text: string }>)[0]!.text);
     expect(beforeParsed.result.count).toBe(1);
 
-    // Usuń plik będący źródłem linku
+    // Delete the file that is a link source
     await client.callTool({
       name: "vault",
       arguments: { action: "delete", path: "daily/2024-01-01.md" },
@@ -448,8 +448,8 @@ describe("backlink index — live updates via MCP operations", () => {
     expect(afterParsed.result.count).toBe(0);
   });
 
-  it("edit.string_replace aktualizuje indeks backlinków", async () => {
-    // Utwórz cel linkowania
+  it("edit.string_replace updates backlink index", async () => {
+    // Create the link target
     await client.callTool({
       name: "vault",
       arguments: {
@@ -459,7 +459,7 @@ describe("backlink index — live updates via MCP operations", () => {
       },
     });
 
-    // Zamień tekst dodając link (string_replace nie przechodzi przez AST, więc zachowuje wikilinki)
+    // Replace text adding a link (string_replace bypasses AST, so wikilinks are preserved)
     const editResult = await client.callTool({
       name: "edit",
       arguments: {
@@ -480,20 +480,20 @@ describe("backlink index — live updates via MCP operations", () => {
     expect(parsed.result.backlinks[0].sourcePath).toBe("hello.md");
   });
 
-  it("pełna sekwencja: create → backlinks → delete → backlinks", async () => {
-    // 1. Utwórz cel
+  it("full sequence: create → backlinks → delete → backlinks", async () => {
+    // 1. Create target
     await client.callTool({
       name: "vault",
       arguments: { action: "create", path: "target.md", content: "# Target\n" },
     });
 
-    // 2. Utwórz plik linkujący
+    // 2. Create a linking file
     await client.callTool({
       name: "vault",
       arguments: { action: "create", path: "linker.md", content: "See [[target]]\n" },
     });
 
-    // 3. Sprawdź backlinki — powinien być 1
+    // 3. Check backlinks — should be 1
     const mid = await client.callTool({
       name: "view",
       arguments: { action: "backlinks", path: "target.md" },
@@ -501,13 +501,13 @@ describe("backlink index — live updates via MCP operations", () => {
     const midParsed = JSON.parse((mid.content as Array<{ type: string; text: string }>)[0]!.text);
     expect(midParsed.result.count).toBe(1);
 
-    // 4. Usuń plik linkujący
+    // 4. Delete the linking file
     await client.callTool({
       name: "vault",
       arguments: { action: "delete", path: "linker.md" },
     });
 
-    // 5. Sprawdź backlinki — powinien być 0
+    // 5. Check backlinks — should be 0
     const end = await client.callTool({
       name: "view",
       arguments: { action: "backlinks", path: "target.md" },
@@ -544,12 +544,12 @@ describe("system tool", () => {
     expect(parsed.result.totalFiles).toBe(2);
     expect(Array.isArray(parsed.result.folders)).toBe(true);
 
-    // hello.md jest w katalogu głównym, więc "." jest korzeniem
+    // hello.md is in the root directory, so "." is the root
     const root = parsed.result.folders.find((f: { path: string }) => f.path === ".");
     expect(root).toBeDefined();
     expect(root.fileCount).toBe(1);
 
-    // daily/ jest dzieckiem korzenia
+    // daily/ is a child of the root
     const daily = root.children.find((f: { path: string }) => f.path === "daily");
     expect(daily).toBeDefined();
     expect(daily.fileCount).toBe(1);

--- a/src/presentation/mcp-tools.test.ts
+++ b/src/presentation/mcp-tools.test.ts
@@ -7,6 +7,8 @@ import { LocalFileSystemAdapter } from "../infrastructure/local-fs-adapter.js";
 import { InMemoryVectorStore } from "../infrastructure/in-memory-vector-store.js";
 import { WorkflowStateMachine } from "../use-cases/workflow-state.js";
 import type { IEmbeddingProvider } from "../domain/interfaces/index.js";
+import { MarkdownPipeline } from "../use-cases/markdown-pipeline.js";
+import { BacklinkIndexService } from "../use-cases/backlink-index.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 
@@ -41,7 +43,7 @@ beforeEach(async () => {
   );
   await fs.writeFile(
     path.join(tmpDir, "daily/2024-01-01.md"),
-    "# Daily Note\n\nToday I learned about MCP.\n",
+    "# Daily Note\n\nToday I learned about MCP. See [[hello]].\n",
   );
 
   const fsAdapter = await LocalFileSystemAdapter.create(tmpDir);
@@ -49,7 +51,15 @@ beforeEach(async () => {
   const embedder = new FakeEmbedder();
   const workflow = new WorkflowStateMachine();
 
-  deps = { fsAdapter, vectorStore, embedder, workflow, vaultRoot: tmpDir };
+  // Indeks backlinków
+  const backlinkPipeline = new MarkdownPipeline();
+  const backlinkIndex = new BacklinkIndexService(backlinkPipeline);
+  backlinkIndex.rebuildIndex([
+    { path: "hello.md", content: "---\ntitle: Hello\n---\n\n# Hello World\n\nWelcome to the vault.\n\n## Getting Started\n\nStart here.\n" },
+    { path: "daily/2024-01-01.md", content: "# Daily Note\n\nToday I learned about MCP. See [[hello]].\n" },
+  ]);
+
+  deps = { fsAdapter, vectorStore, embedder, workflow, vaultRoot: tmpDir, backlinkIndex };
 
   const server = createMcpServer(deps);
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -223,6 +233,21 @@ describe("view tool", () => {
     });
     expect(result.isError).toBe(true);
   });
+
+  it("returns backlinks for a target note", async () => {
+    const result = await client.callTool({
+      name: "view",
+      arguments: { action: "backlinks", path: "hello.md" },
+    });
+    const content = result.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0]!.text);
+
+    expect(parsed.result.target).toBe("hello.md");
+    expect(parsed.result.count).toBe(1);
+    expect(parsed.result.backlinks).toHaveLength(1);
+    expect(parsed.result.backlinks[0].sourcePath).toBe("daily/2024-01-01.md");
+    expect(parsed.result.backlinks[0].linkType).toBe("wikilink");
+  });
 });
 
 // ── edit tool ─────────────────────────────────────────────────────
@@ -318,6 +343,29 @@ describe("edit tool", () => {
     });
     expect(result.isError).toBe(true);
   });
+
+  it("executes batch edit with multiple operations", async () => {
+    const result = await client.callTool({
+      name: "edit",
+      arguments: {
+        operations: [
+          { path: "hello.md", operation: "append", content: "Batch line 1." },
+          { path: "daily/2024-01-01.md", operation: "append", content: "Batch line 2." },
+        ],
+      },
+    });
+    const content = result.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0]!.text);
+
+    expect(parsed.result.totalRequested).toBe(2);
+    expect(parsed.result.totalSucceeded).toBe(2);
+    expect(parsed.result.totalFailed).toBe(0);
+
+    const file1 = await fs.readFile(path.join(tmpDir, "hello.md"), "utf-8");
+    expect(file1).toContain("Batch line 1.");
+    const file2 = await fs.readFile(path.join(tmpDir, "daily/2024-01-01.md"), "utf-8");
+    expect(file2).toContain("Batch line 2.");
+  });
 });
 
 // ── workflow tool ─────────────────────────────────────────────────
@@ -364,5 +412,27 @@ describe("system tool", () => {
     const parsed = JSON.parse(content[0]!.text);
     expect(parsed.result.vaultRoot).toBe(tmpDir);
     expect(typeof parsed.result.indexedDocuments).toBe("number");
+  });
+
+  it("returns vault overview with folder structure", async () => {
+    const result = await client.callTool({
+      name: "system",
+      arguments: { action: "overview" },
+    });
+    const content = result.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0]!.text);
+
+    expect(parsed.result.totalFiles).toBe(2);
+    expect(Array.isArray(parsed.result.folders)).toBe(true);
+
+    // hello.md jest w katalogu głównym, więc "." jest korzeniem
+    const root = parsed.result.folders.find((f: { path: string }) => f.path === ".");
+    expect(root).toBeDefined();
+    expect(root.fileCount).toBe(1);
+
+    // daily/ jest dzieckiem korzenia
+    const daily = root.children.find((f: { path: string }) => f.path === "daily");
+    expect(daily).toBeDefined();
+    expect(daily.fileCount).toBe(1);
   });
 });

--- a/src/presentation/mcp-tools.ts
+++ b/src/presentation/mcp-tools.ts
@@ -18,6 +18,9 @@ import { GetFrontmatterUseCase, SetFrontmatterUseCase } from "../use-cases/front
 import { UpdateFileUseCase } from "../use-cases/update-file.js";
 import { DryRunEditor } from "../use-cases/dry-run-edit.js";
 import { CreateFromTemplateUseCase } from "../use-cases/create-from-template.js";
+import { BatchEditService, type EditOperation } from "../use-cases/batch-edit.js";
+import { VaultOverviewService } from "../use-cases/vault-overview.js";
+import { BacklinkIndexService } from "../use-cases/backlink-index.js";
 import { MarkdownFileRepository } from "../infrastructure/markdown-file-repository.js";
 import { RegexTemplateEngine } from "../infrastructure/regex-template-engine.js";
 import { UnifiedDiffService } from "../infrastructure/diff-service.js";
@@ -29,6 +32,7 @@ export interface McpDependencies {
   embedder: IEmbeddingProvider;
   workflow: WorkflowStateMachine;
   vaultRoot: string;
+  backlinkIndex?: BacklinkIndexService | undefined;
 }
 
 /**
@@ -115,11 +119,11 @@ export function createMcpServer(deps: McpDependencies): McpServer {
   server.registerTool("edit", {
     title: "Edit",
     description:
-      "Edit a note. AST operations (append/prepend/replace) target headings or block IDs with fuzzy matching. Freeform operations (line_replace/string_replace) provide fallback editing by line range or literal string. frontmatter_set merges fields into YAML frontmatter. Set dryRun=true to preview changes as a unified diff without saving.",
+      "Edit notes. Single mode: provide path, operation, content. Batch mode: provide operations array (max 50, sequential, stops on first error). AST ops (append/prepend/replace) target headings or block IDs with fuzzy matching. Freeform ops (line_replace/string_replace) for line range or literal string. frontmatter_set merges YAML. dryRun=true previews as unified diff without writing.",
     inputSchema: {
-      path: z.string(),
-      operation: z.enum(["append", "prepend", "replace", "line_replace", "string_replace", "frontmatter_set"]),
-      content: z.string(),
+      path: z.string().optional().describe("Note path (required for single edit)."),
+      operation: z.enum(["append", "prepend", "replace", "line_replace", "string_replace", "frontmatter_set"]).optional().describe("Edit operation (required for single edit)."),
+      content: z.string().optional().describe("Content to apply (required for single edit)."),
       heading: z.string().optional(),
       headingDepth: z.number().optional(),
       blockId: z.string().optional(),
@@ -128,9 +132,37 @@ export function createMcpServer(deps: McpDependencies): McpServer {
       searchText: z.string().optional(),
       replaceAll: z.boolean().optional(),
       dryRun: z.boolean().optional().describe("If true, returns a preview of changes as a unified diff without saving to disk."),
+      operations: z.array(z.object({
+        path: z.string(),
+        operation: z.enum(["append", "prepend", "replace", "line_replace", "string_replace", "frontmatter_set"]),
+        content: z.string(),
+        heading: z.string().optional(),
+        headingDepth: z.number().optional(),
+        blockId: z.string().optional(),
+        startLine: z.number().optional(),
+        endLine: z.number().optional(),
+        searchText: z.string().optional(),
+        replaceAll: z.boolean().optional(),
+      })).optional().describe("For batch mode: array of edit operations (max 50). Executed sequentially, stops on first error."),
     },
-  }, async ({ path: notePath, operation, content, heading, headingDepth, blockId, startLine, endLine, searchText, replaceAll, dryRun }) => {
+  }, async ({ path: notePath, operation, content, heading, headingDepth, blockId, startLine, endLine, searchText, replaceAll, dryRun, operations }) => {
     return wrapTool(deps.workflow, "edit", async () => {
+      // ── Tryb batch ─────────────────────────────────────────────
+      if (operations && operations.length > 0) {
+        const diffService = new UnifiedDiffService();
+        const repo = new MarkdownFileRepository(deps.fsAdapter, pipeline);
+        const batchService = new BatchEditService(deps.fsAdapter, pipeline, diffService, repo);
+        return batchService.execute({
+          operations: operations as EditOperation[],
+          dryRun,
+        });
+      }
+
+      // ── Tryb pojedynczy — walidacja wymaganych pól ─────────────
+      if (!notePath) throw new Error("path is required for single edit");
+      if (!operation) throw new Error("operation is required for single edit");
+      if (content === undefined) throw new Error("content is required for single edit");
+
       const source = await deps.fsAdapter.readNote(notePath);
       const diffService = new UnifiedDiffService();
       const dryRunEditor = new DryRunEditor(deps.fsAdapter, diffService);
@@ -224,9 +256,9 @@ export function createMcpServer(deps: McpDependencies): McpServer {
   server.registerTool("view", {
     title: "View",
     description:
-      "View and search notes. Actions: search (single-file fragment retrieval), global_search (cross-vault keyword search), semantic_search (cross-vault vector+lexical hybrid), outline (heading structure), read (full content or by heading), frontmatter_get (read YAML frontmatter), bulk_read (read multiple files/headings in one call).",
+      "View and search notes. Actions: search (single-file fragment retrieval), global_search (cross-vault keyword search), semantic_search (cross-vault vector+lexical hybrid), outline (heading structure), read (full content or by heading), frontmatter_get (read YAML frontmatter), bulk_read (read multiple files/headings in one call), backlinks (find all notes linking to a given path).",
     inputSchema: {
-      action: z.enum(["search", "global_search", "semantic_search", "outline", "read", "frontmatter_get", "bulk_read"]),
+      action: z.enum(["search", "global_search", "semantic_search", "outline", "read", "frontmatter_get", "bulk_read", "backlinks"]),
       path: z.string().optional(),
       query: z.string().optional(),
       maxChunks: z.number().optional(),
@@ -323,6 +355,14 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           const result = await bulkUseCase.execute({ items });
           return result;
         }
+        case "backlinks": {
+          if (!notePath) throw new Error("path is required for backlinks");
+          if (!deps.backlinkIndex) {
+            return { target: notePath, backlinks: [], count: 0 };
+          }
+          const backlinks = deps.backlinkIndex.getBacklinks(notePath);
+          return { target: notePath, backlinks, count: backlinks.length };
+        }
         default:
           throw new Error(`Unknown view action: ${String(action)}`);
       }
@@ -376,11 +416,12 @@ export function createMcpServer(deps: McpDependencies): McpServer {
   server.registerTool("system", {
     title: "System",
     description:
-      "System administration: check status, get indexing info, and manage the server.",
+      "System administration: check status, get indexing info, vault structure overview, and manage the server.",
     inputSchema: {
-      action: z.enum(["status", "reindex"]),
+      action: z.enum(["status", "reindex", "overview"]),
+      maxDepth: z.number().optional().describe("Maximum folder depth for overview (default 3)."),
     },
-  }, async ({ action }) => {
+  }, async ({ action, maxDepth }) => {
     return wrapTool(deps.workflow, "system", async () => {
       switch (action) {
         case "status": {
@@ -393,6 +434,10 @@ export function createMcpServer(deps: McpDependencies): McpServer {
         }
         case "reindex": {
           return { message: "Re-indexing triggered (async)" };
+        }
+        case "overview": {
+          const overviewService = new VaultOverviewService(deps.fsAdapter);
+          return overviewService.getOverview(maxDepth);
         }
         default:
           throw new Error(`Unknown system action: ${String(action)}`);

--- a/src/presentation/mcp-tools.ts
+++ b/src/presentation/mcp-tools.ts
@@ -21,6 +21,7 @@ import { CreateFromTemplateUseCase } from "../use-cases/create-from-template.js"
 import { BatchEditService, type EditOperation } from "../use-cases/batch-edit.js";
 import { VaultOverviewService } from "../use-cases/vault-overview.js";
 import { BacklinkIndexService } from "../use-cases/backlink-index.js";
+import { VaultIndexer } from "../use-cases/vault-indexer.js";
 import { MarkdownFileRepository } from "../infrastructure/markdown-file-repository.js";
 import { RegexTemplateEngine } from "../infrastructure/regex-template-engine.js";
 import { UnifiedDiffService } from "../infrastructure/diff-service.js";
@@ -33,6 +34,7 @@ export interface McpDependencies {
   workflow: WorkflowStateMachine;
   vaultRoot: string;
   backlinkIndex?: BacklinkIndexService | undefined;
+  indexer?: VaultIndexer | undefined;
 }
 
 /**
@@ -77,6 +79,8 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           if (!path) throw new Error("path is required for create");
           if (!content) throw new Error("content is required for create");
           await deps.fsAdapter.writeNote(path, content);
+          deps.backlinkIndex?.updateFile(path, content);
+          deps.indexer?.indexFile(path).catch(() => {/* tło */});
           return `Note created: ${path}`;
         }
         case "update": {
@@ -84,11 +88,15 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           if (!content) throw new Error("content is required for update");
           const useCase = new UpdateFileUseCase(deps.fsAdapter);
           const result = await useCase.execute({ path, content });
+          deps.backlinkIndex?.updateFile(path, content);
+          deps.indexer?.indexFile(path).catch(() => {/* tło */});
           return result.message;
         }
         case "delete": {
           if (!path) throw new Error("path is required for delete");
           await deps.fsAdapter.deleteNote(path);
+          deps.backlinkIndex?.removeFile(path);
+          deps.indexer?.removeFile(path).catch(() => {/* tło */});
           return `Note deleted: ${path}`;
         }
         case "stat": {
@@ -106,6 +114,10 @@ export function createMcpServer(deps: McpDependencies): McpServer {
             destinationPath: path,
             variables,
           });
+          // Zaktualizuj indeksy po utworzeniu z szablonu
+          const created = await deps.fsAdapter.readNote(path);
+          deps.backlinkIndex?.updateFile(path, created);
+          deps.indexer?.indexFile(path).catch(() => {/* tło */});
           return result.message;
         }
         default:
@@ -147,15 +159,34 @@ export function createMcpServer(deps: McpDependencies): McpServer {
     },
   }, async ({ path: notePath, operation, content, heading, headingDepth, blockId, startLine, endLine, searchText, replaceAll, dryRun, operations }) => {
     return wrapTool(deps.workflow, "edit", async () => {
+      // Helper: aktualizuj indeksy po zapisie pliku
+      // Backlinki synchronicznie (wymagane dla spójności), wektory w tle
+      const syncIndexes = async (filePath: string): Promise<void> => {
+        const updated = await deps.fsAdapter.readNote(filePath);
+        deps.backlinkIndex?.updateFile(filePath, updated);
+        deps.indexer?.indexFile(filePath).catch(() => {/* tło */});
+      };
+
       // ── Tryb batch ─────────────────────────────────────────────
       if (operations && operations.length > 0) {
         const diffService = new UnifiedDiffService();
         const repo = new MarkdownFileRepository(deps.fsAdapter, pipeline);
         const batchService = new BatchEditService(deps.fsAdapter, pipeline, diffService, repo);
-        return batchService.execute({
+        const batchResult = await batchService.execute({
           operations: operations as EditOperation[],
           dryRun,
         });
+        // Zaktualizuj indeksy dla każdej pomyślnej operacji (nie dryRun)
+        if (!dryRun) {
+          const edited = new Set<string>();
+          for (const op of operations as EditOperation[]) {
+            edited.add(op.path);
+          }
+          for (const p of edited) {
+            await syncIndexes(p);
+          }
+        }
+        return batchResult;
       }
 
       // ── Tryb pojedynczy — walidacja wymaganych pól ─────────────
@@ -167,19 +198,28 @@ export function createMcpServer(deps: McpDependencies): McpServer {
       const diffService = new UnifiedDiffService();
       const dryRunEditor = new DryRunEditor(deps.fsAdapter, diffService);
 
+      // Helper: wykonaj edycję i zaktualizuj indeksy jeśli nie dryRun
+      const executeEdit = async (editResult: unknown): Promise<unknown> => {
+        if (!(dryRun ?? false)) {
+          await syncIndexes(notePath);
+        }
+        return editResult;
+      };
+
       // ── Freeform operations ─────────────────────────────────────
       if (operation === "line_replace") {
         if (startLine === undefined || endLine === undefined) {
           throw new Error("startLine and endLine are required for line_replace");
         }
         const newContent = FreeformEditor.lineReplace(source, startLine, endLine, content);
-        return dryRunEditor.execute({
+        const result = await dryRunEditor.execute({
           path: notePath,
           oldContent: source,
           newContent,
           dryRun: dryRun ?? false,
           operationLabel: `line_replace lines ${startLine}-${endLine}`,
         });
+        return executeEdit(result);
       }
 
       if (operation === "string_replace") {
@@ -187,13 +227,14 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           throw new Error("searchText is required for string_replace");
         }
         const newContent = FreeformEditor.stringReplace(source, searchText, content, replaceAll ?? false);
-        return dryRunEditor.execute({
+        const result = await dryRunEditor.execute({
           path: notePath,
           oldContent: source,
           newContent,
           dryRun: dryRun ?? false,
           operationLabel: "string_replace",
         });
+        return executeEdit(result);
       }
 
       // ── Frontmatter operation ──────────────────────────────────
@@ -201,6 +242,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
         const repo = new MarkdownFileRepository(deps.fsAdapter, pipeline);
         const useCase = new SetFrontmatterUseCase(repo);
         const result = await useCase.execute({ path: notePath, content });
+        await syncIndexes(notePath);
         return result.message;
       }
 
@@ -238,13 +280,14 @@ export function createMcpServer(deps: McpDependencies): McpServer {
       AstPatcher.apply(tree, { type: operation, target, content }, pipeline);
       const newContent = pipeline.stringify(tree);
 
-      return dryRunEditor.execute({
+      const result = await dryRunEditor.execute({
         path: notePath,
         oldContent: source,
         newContent,
         dryRun: dryRun ?? false,
         operationLabel: operation,
       });
+      return executeEdit(result);
     });
   });
 
@@ -429,10 +472,30 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           return {
             vaultRoot: deps.vaultRoot,
             indexedDocuments: indexedDocs,
+            backlinkIndexSize: deps.backlinkIndex?.indexSize ?? 0,
             workflowState: deps.workflow.currentPlace,
           };
         }
         case "reindex": {
+          if (deps.indexer) {
+            // Uruchom reindeksację asynchronicznie (nie blokuj odpowiedzi)
+            deps.indexer.indexAll()
+              .then(async () => {
+                if (deps.backlinkIndex) {
+                  const allFiles = await deps.fsAdapter.listNotes();
+                  const entries = await Promise.all(
+                    allFiles.map(async (p) => ({
+                      path: p,
+                      content: await deps.fsAdapter.readNote(p),
+                    })),
+                  );
+                  deps.backlinkIndex.rebuildIndex(entries);
+                }
+              })
+              .catch((err: unknown) =>
+                console.error("Re-indexing failed:", err),
+              );
+          }
           return { message: "Re-indexing triggered (async)" };
         }
         case "overview": {

--- a/src/presentation/mcp-tools.ts
+++ b/src/presentation/mcp-tools.ts
@@ -80,7 +80,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           if (!content) throw new Error("content is required for create");
           await deps.fsAdapter.writeNote(path, content);
           deps.backlinkIndex?.updateFile(path, content);
-          deps.indexer?.indexFile(path).catch(() => {/* tło */});
+          deps.indexer?.indexFile(path).catch(() => {/* background */});
           return `Note created: ${path}`;
         }
         case "update": {
@@ -89,14 +89,14 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           const useCase = new UpdateFileUseCase(deps.fsAdapter);
           const result = await useCase.execute({ path, content });
           deps.backlinkIndex?.updateFile(path, content);
-          deps.indexer?.indexFile(path).catch(() => {/* tło */});
+          deps.indexer?.indexFile(path).catch(() => {/* background */});
           return result.message;
         }
         case "delete": {
           if (!path) throw new Error("path is required for delete");
           await deps.fsAdapter.deleteNote(path);
           deps.backlinkIndex?.removeFile(path);
-          deps.indexer?.removeFile(path).catch(() => {/* tło */});
+          deps.indexer?.removeFile(path).catch(() => {/* background */});
           return `Note deleted: ${path}`;
         }
         case "stat": {
@@ -114,10 +114,10 @@ export function createMcpServer(deps: McpDependencies): McpServer {
             destinationPath: path,
             variables,
           });
-          // Zaktualizuj indeksy po utworzeniu z szablonu
+          // Update indexes after template creation
           const created = await deps.fsAdapter.readNote(path);
           deps.backlinkIndex?.updateFile(path, created);
-          deps.indexer?.indexFile(path).catch(() => {/* tło */});
+          deps.indexer?.indexFile(path).catch(() => {/* background */});
           return result.message;
         }
         default:
@@ -159,15 +159,15 @@ export function createMcpServer(deps: McpDependencies): McpServer {
     },
   }, async ({ path: notePath, operation, content, heading, headingDepth, blockId, startLine, endLine, searchText, replaceAll, dryRun, operations }) => {
     return wrapTool(deps.workflow, "edit", async () => {
-      // Helper: aktualizuj indeksy po zapisie pliku
-      // Backlinki synchronicznie (wymagane dla spójności), wektory w tle
+      // Helper: update indexes after file write
+      // Backlinks synchronously (required for consistency), vectors in background
       const syncIndexes = async (filePath: string): Promise<void> => {
         const updated = await deps.fsAdapter.readNote(filePath);
         deps.backlinkIndex?.updateFile(filePath, updated);
-        deps.indexer?.indexFile(filePath).catch(() => {/* tło */});
+        deps.indexer?.indexFile(filePath).catch(() => {/* background */});
       };
 
-      // ── Tryb batch ─────────────────────────────────────────────
+      // ── Batch mode ─────────────────────────────────────────────
       if (operations && operations.length > 0) {
         const diffService = new UnifiedDiffService();
         const repo = new MarkdownFileRepository(deps.fsAdapter, pipeline);
@@ -176,7 +176,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           operations: operations as EditOperation[],
           dryRun,
         });
-        // Zaktualizuj indeksy dla każdej pomyślnej operacji (nie dryRun)
+        // Update indexes for each successfully edited file (not dryRun)
         if (!dryRun) {
           const edited = new Set<string>();
           for (const op of operations as EditOperation[]) {
@@ -189,7 +189,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
         return batchResult;
       }
 
-      // ── Tryb pojedynczy — walidacja wymaganych pól ─────────────
+      // ── Single mode — validate required fields ─────────────
       if (!notePath) throw new Error("path is required for single edit");
       if (!operation) throw new Error("operation is required for single edit");
       if (content === undefined) throw new Error("content is required for single edit");
@@ -198,7 +198,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
       const diffService = new UnifiedDiffService();
       const dryRunEditor = new DryRunEditor(deps.fsAdapter, diffService);
 
-      // Helper: wykonaj edycję i zaktualizuj indeksy jeśli nie dryRun
+      // Helper: finalize edit and update indexes if not dryRun
       const executeEdit = async (editResult: unknown): Promise<unknown> => {
         if (!(dryRun ?? false)) {
           await syncIndexes(notePath);
@@ -478,7 +478,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
         }
         case "reindex": {
           if (deps.indexer) {
-            // Uruchom reindeksację asynchronicznie (nie blokuj odpowiedzi)
+            // Run re-indexing asynchronously (don't block the response)
             deps.indexer.indexAll()
               .then(async () => {
                 if (deps.backlinkIndex) {

--- a/src/use-cases/backlink-index.test.ts
+++ b/src/use-cases/backlink-index.test.ts
@@ -101,6 +101,22 @@ describe("BacklinkIndexService", () => {
     expect(backlinks).toHaveLength(0);
   });
 
+  it("removeFile usuwa wpisy backlinków z tego źródła", () => {
+    service.rebuildIndex([
+      { path: "a.md", content: "See [[C]].\n" },
+      { path: "b.md", content: "Also [[C]].\n" },
+      { path: "c.md", content: "# C\n" },
+    ]);
+
+    expect(service.getBacklinks("c.md")).toHaveLength(2);
+
+    service.removeFile("a.md");
+
+    const remaining = service.getBacklinks("c.md");
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]!.sourcePath).toBe("b.md");
+  });
+
   it("normalizacja celu niezależna od wielkości liter", () => {
     service.rebuildIndex([
       { path: "a.md", content: "See [[B]].\n" },

--- a/src/use-cases/backlink-index.test.ts
+++ b/src/use-cases/backlink-index.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { MarkdownPipeline } from "./markdown-pipeline.js";
+import { BacklinkIndexService } from "./backlink-index.js";
+
+let service: BacklinkIndexService;
+
+beforeEach(() => {
+  service = new BacklinkIndexService(new MarkdownPipeline());
+});
+
+describe("BacklinkIndexService", () => {
+  it("zwraca pusty wynik dla pustego indeksu", () => {
+    const result = service.getBacklinks("any.md");
+    expect(result).toEqual([]);
+  });
+
+  it("indeksuje wikilink [[B]] — backlink typu wikilink", () => {
+    service.rebuildIndex([
+      { path: "a.md", content: "# A\n\nSee [[B]].\n" },
+      { path: "b.md", content: "# B\n" },
+    ]);
+
+    const backlinks = service.getBacklinks("b.md");
+    expect(backlinks).toHaveLength(1);
+    expect(backlinks[0]!.sourcePath).toBe("a.md");
+    expect(backlinks[0]!.linkType).toBe("wikilink");
+  });
+
+  it("indeksuje markdown link [text](B.md) — backlink typu markdown_link", () => {
+    service.rebuildIndex([
+      { path: "a.md", content: "# A\n\nSee [B doc](b.md).\n" },
+      { path: "b.md", content: "# B\n" },
+    ]);
+
+    const backlinks = service.getBacklinks("b.md");
+    expect(backlinks).toHaveLength(1);
+    expect(backlinks[0]!.sourcePath).toBe("a.md");
+    expect(backlinks[0]!.linkType).toBe("markdown_link");
+  });
+
+  it("wiele plików linkujących do tego samego celu", () => {
+    service.rebuildIndex([
+      { path: "a.md", content: "Link to [[C]].\n" },
+      { path: "b.md", content: "Also links to [[C]].\n" },
+      { path: "c.md", content: "# C\n" },
+    ]);
+
+    const backlinks = service.getBacklinks("c.md");
+    expect(backlinks).toHaveLength(2);
+    const sources = backlinks.map((b) => b.sourcePath).sort();
+    expect(sources).toEqual(["a.md", "b.md"]);
+  });
+
+  it("rozwiązuje wikilink po nazwie pliku", () => {
+    service.rebuildIndex([
+      { path: "a.md", content: "See [[Note Title]].\n" },
+      { path: "folder/Note Title.md", content: "# Note Title\n" },
+    ]);
+
+    const backlinks = service.getBacklinks("folder/Note Title.md");
+    expect(backlinks).toHaveLength(1);
+    expect(backlinks[0]!.sourcePath).toBe("a.md");
+    expect(backlinks[0]!.linkType).toBe("wikilink");
+  });
+
+  it("updateFile zastępuje stare wpisy dla tego źródła", () => {
+    service.rebuildIndex([
+      { path: "a.md", content: "See [[B]].\n" },
+      { path: "b.md", content: "# B\n" },
+      { path: "c.md", content: "# C\n" },
+    ]);
+
+    expect(service.getBacklinks("b.md")).toHaveLength(1);
+    expect(service.getBacklinks("c.md")).toHaveLength(0);
+
+    // Zmień a.md — teraz linkuje do C zamiast B
+    service.updateFile("a.md", "Now see [[C]].\n");
+
+    expect(service.getBacklinks("b.md")).toHaveLength(0);
+    expect(service.getBacklinks("c.md")).toHaveLength(1);
+  });
+
+  it("poprawnie wyodrębnia numer linii i kontekst", () => {
+    service.rebuildIndex([
+      { path: "a.md", content: "# Title\n\nFirst paragraph.\n\nSee [[B]] for details.\n" },
+      { path: "b.md", content: "# B\n" },
+    ]);
+
+    const backlinks = service.getBacklinks("b.md");
+    expect(backlinks).toHaveLength(1);
+    expect(backlinks[0]!.lineNumber).toBe(5);
+    expect(backlinks[0]!.context).toContain("[[B]]");
+  });
+
+  it("pomija self-linki", () => {
+    service.rebuildIndex([
+      { path: "a.md", content: "# A\n\nSee [[A]] and [self](a.md).\n" },
+    ]);
+
+    const backlinks = service.getBacklinks("a.md");
+    expect(backlinks).toHaveLength(0);
+  });
+
+  it("normalizacja celu niezależna od wielkości liter", () => {
+    service.rebuildIndex([
+      { path: "a.md", content: "See [[B]].\n" },
+      { path: "B.md", content: "# B\n" },
+    ]);
+
+    // Zapytanie z wielką literą
+    expect(service.getBacklinks("B.md")).toHaveLength(1);
+    // Zapytanie z małą literą
+    expect(service.getBacklinks("b.md")).toHaveLength(1);
+  });
+});

--- a/src/use-cases/backlink-index.test.ts
+++ b/src/use-cases/backlink-index.test.ts
@@ -9,12 +9,12 @@ beforeEach(() => {
 });
 
 describe("BacklinkIndexService", () => {
-  it("zwraca pusty wynik dla pustego indeksu", () => {
+  it("returns empty result for an empty index", () => {
     const result = service.getBacklinks("any.md");
     expect(result).toEqual([]);
   });
 
-  it("indeksuje wikilink [[B]] — backlink typu wikilink", () => {
+  it("indexes wikilink [[B]] — wikilink type backlink", () => {
     service.rebuildIndex([
       { path: "a.md", content: "# A\n\nSee [[B]].\n" },
       { path: "b.md", content: "# B\n" },
@@ -26,7 +26,7 @@ describe("BacklinkIndexService", () => {
     expect(backlinks[0]!.linkType).toBe("wikilink");
   });
 
-  it("indeksuje markdown link [text](B.md) — backlink typu markdown_link", () => {
+  it("indexes markdown link [text](B.md) — markdown_link type backlink", () => {
     service.rebuildIndex([
       { path: "a.md", content: "# A\n\nSee [B doc](b.md).\n" },
       { path: "b.md", content: "# B\n" },
@@ -38,7 +38,7 @@ describe("BacklinkIndexService", () => {
     expect(backlinks[0]!.linkType).toBe("markdown_link");
   });
 
-  it("wiele plików linkujących do tego samego celu", () => {
+  it("multiple files linking to the same target", () => {
     service.rebuildIndex([
       { path: "a.md", content: "Link to [[C]].\n" },
       { path: "b.md", content: "Also links to [[C]].\n" },
@@ -51,7 +51,7 @@ describe("BacklinkIndexService", () => {
     expect(sources).toEqual(["a.md", "b.md"]);
   });
 
-  it("rozwiązuje wikilink po nazwie pliku", () => {
+  it("resolves wikilink by filename", () => {
     service.rebuildIndex([
       { path: "a.md", content: "See [[Note Title]].\n" },
       { path: "folder/Note Title.md", content: "# Note Title\n" },
@@ -63,7 +63,7 @@ describe("BacklinkIndexService", () => {
     expect(backlinks[0]!.linkType).toBe("wikilink");
   });
 
-  it("updateFile zastępuje stare wpisy dla tego źródła", () => {
+  it("updateFile replaces old entries for the source", () => {
     service.rebuildIndex([
       { path: "a.md", content: "See [[B]].\n" },
       { path: "b.md", content: "# B\n" },
@@ -73,14 +73,14 @@ describe("BacklinkIndexService", () => {
     expect(service.getBacklinks("b.md")).toHaveLength(1);
     expect(service.getBacklinks("c.md")).toHaveLength(0);
 
-    // Zmień a.md — teraz linkuje do C zamiast B
+    // Change a.md — now links to C instead of B
     service.updateFile("a.md", "Now see [[C]].\n");
 
     expect(service.getBacklinks("b.md")).toHaveLength(0);
     expect(service.getBacklinks("c.md")).toHaveLength(1);
   });
 
-  it("poprawnie wyodrębnia numer linii i kontekst", () => {
+  it("correctly extracts line number and context", () => {
     service.rebuildIndex([
       { path: "a.md", content: "# Title\n\nFirst paragraph.\n\nSee [[B]] for details.\n" },
       { path: "b.md", content: "# B\n" },
@@ -92,7 +92,7 @@ describe("BacklinkIndexService", () => {
     expect(backlinks[0]!.context).toContain("[[B]]");
   });
 
-  it("pomija self-linki", () => {
+  it("skips self-links", () => {
     service.rebuildIndex([
       { path: "a.md", content: "# A\n\nSee [[A]] and [self](a.md).\n" },
     ]);
@@ -101,7 +101,7 @@ describe("BacklinkIndexService", () => {
     expect(backlinks).toHaveLength(0);
   });
 
-  it("removeFile usuwa wpisy backlinków z tego źródła", () => {
+  it("removeFile removes backlink entries from that source", () => {
     service.rebuildIndex([
       { path: "a.md", content: "See [[C]].\n" },
       { path: "b.md", content: "Also [[C]].\n" },
@@ -117,15 +117,15 @@ describe("BacklinkIndexService", () => {
     expect(remaining[0]!.sourcePath).toBe("b.md");
   });
 
-  it("normalizacja celu niezależna od wielkości liter", () => {
+  it("target normalization is case-insensitive", () => {
     service.rebuildIndex([
       { path: "a.md", content: "See [[B]].\n" },
       { path: "B.md", content: "# B\n" },
     ]);
 
-    // Zapytanie z wielką literą
+    // Query with uppercase
     expect(service.getBacklinks("B.md")).toHaveLength(1);
-    // Zapytanie z małą literą
+    // Query with lowercase
     expect(service.getBacklinks("b.md")).toHaveLength(1);
   });
 });

--- a/src/use-cases/backlink-index.ts
+++ b/src/use-cases/backlink-index.ts
@@ -4,7 +4,7 @@ import type { IBacklinkIndex, BacklinkEntry } from "../domain/interfaces/backlin
 import type { MarkdownPipeline } from "./markdown-pipeline.js";
 import { WikilinkResolver } from "./wikilink-resolver.js";
 
-// Klucz mapy to znormalizowana ścieżka: lowercase, bez rozszerzenia .md
+// Map key is the normalized path: lowercase, without .md extension
 function normalizeKey(filePath: string): string {
   const withoutExt = filePath.endsWith(".md")
     ? filePath.slice(0, -3)
@@ -12,7 +12,7 @@ function normalizeKey(filePath: string): string {
   return withoutExt.toLowerCase();
 }
 
-// Numer linii na podstawie pozycji (offset) w tekście
+// Line number based on character offset in the text
 function lineAtOffset(content: string, offset: number): number {
   let line = 1;
   for (let i = 0; i < offset && i < content.length; i++) {
@@ -21,7 +21,7 @@ function lineAtOffset(content: string, offset: number): number {
   return line;
 }
 
-// Fragment kontekstowy ±30 znaków wokół pozycji
+// Context snippet ±30 characters around the position
 function extractContext(
   content: string,
   offset: number,
@@ -32,12 +32,12 @@ function extractContext(
   return content.slice(start, end).replace(/\n/g, " ");
 }
 
-// Sprawdza czy URL jest zewnętrzny (http, mailto, itp.)
+// Checks if a URL is external (http, mailto, etc.)
 function isExternalUrl(url: string): boolean {
   return /^[a-z]+:\/\//i.test(url) || url.startsWith("mailto:") || url.startsWith("#");
 }
 
-// Rozwiązuje relatywny link markdown na ścieżkę vault-relative
+// Resolves a relative markdown link to a vault-relative path
 function resolveRelativeLink(sourcePath: string, url: string): string {
   const cleanUrl = url.split("#")[0]!.split("?")[0]!;
   if (!cleanUrl) return "";
@@ -45,7 +45,7 @@ function resolveRelativeLink(sourcePath: string, url: string): string {
   return path.posix.normalize(path.posix.join(dir, cleanUrl));
 }
 
-// Rekurencyjne szukanie węzłów danego typu w drzewie AST
+// Recursively find nodes of a given type in the AST tree
 interface LinkNode {
   type: "link";
   url: string;
@@ -66,7 +66,7 @@ function findLinkNodes(node: unknown): LinkNode[] {
   return results;
 }
 
-// Wyodrębnia wikilinki z pozycjami w tekście
+// Extracts wikilinks with their positions in the text
 interface WikilinkMatch {
   target: string;
   index: number;
@@ -88,8 +88,8 @@ function extractWikilinksWithPositions(content: string): WikilinkMatch[] {
 }
 
 /**
- * Usługa indeksująca backlinki w vault.
- * Przechowuje mapę: znormalizowana ścieżka docelowa → lista wpisów BacklinkEntry.
+ * Service that indexes backlinks in the vault.
+ * Stores a map: normalized target path → list of BacklinkEntry records.
  */
 export class BacklinkIndexService implements IBacklinkIndex {
   private readonly index = new Map<string, BacklinkEntry[]>();
@@ -97,7 +97,7 @@ export class BacklinkIndexService implements IBacklinkIndex {
 
   constructor(private readonly pipeline: MarkdownPipeline) {}
 
-  /** Liczba unikalnych celów śledzonych w indeksie. */
+  /** Number of unique targets tracked in the index. */
   get indexSize(): number {
     return this.index.size;
   }
@@ -116,13 +116,13 @@ export class BacklinkIndexService implements IBacklinkIndex {
   }
 
   updateFile(filePath: string, content: string): void {
-    // Usuń stare wpisy i dodaj nowe
+    // Remove old entries and add new ones
     this.removeFile(filePath);
     this.processFile(filePath, content);
   }
 
   removeFile(filePath: string): void {
-    // Usuń wszystkie wpisy gdzie sourcePath === filePath
+    // Remove all entries where sourcePath === filePath
     for (const [key, entries] of this.index) {
       const filtered = entries.filter((e) => e.sourcePath !== filePath);
       if (filtered.length === 0) {
@@ -136,14 +136,14 @@ export class BacklinkIndexService implements IBacklinkIndex {
   private processFile(sourcePath: string, content: string): void {
     const sourceKey = normalizeKey(sourcePath);
 
-    // Wyodrębnij wikilinki
+    // Extract wikilinks
     const wikilinks = extractWikilinksWithPositions(content);
     for (const wl of wikilinks) {
       const resolved = this.resolver?.resolve(wl.target);
       const targetPath = resolved ?? `${wl.target}.md`;
       const targetKey = normalizeKey(targetPath);
 
-      // Pomiń self-linki
+      // Skip self-links
       if (targetKey === sourceKey) continue;
 
       this.addEntry(targetKey, {
@@ -154,7 +154,7 @@ export class BacklinkIndexService implements IBacklinkIndex {
       });
     }
 
-    // Wyodrębnij linki markdown z AST
+    // Extract markdown links from AST
     const tree: Root = this.pipeline.parse(content);
     const linkNodes = findLinkNodes(tree);
     for (const node of linkNodes) {

--- a/src/use-cases/backlink-index.ts
+++ b/src/use-cases/backlink-index.ts
@@ -97,6 +97,11 @@ export class BacklinkIndexService implements IBacklinkIndex {
 
   constructor(private readonly pipeline: MarkdownPipeline) {}
 
+  /** Liczba unikalnych celów śledzonych w indeksie. */
+  get indexSize(): number {
+    return this.index.size;
+  }
+
   getBacklinks(targetPath: string): BacklinkEntry[] {
     const key = normalizeKey(targetPath);
     return this.index.get(key) ?? [];
@@ -111,7 +116,13 @@ export class BacklinkIndexService implements IBacklinkIndex {
   }
 
   updateFile(filePath: string, content: string): void {
-    // Usuń stare wpisy dla tego pliku źródłowego
+    // Usuń stare wpisy i dodaj nowe
+    this.removeFile(filePath);
+    this.processFile(filePath, content);
+  }
+
+  removeFile(filePath: string): void {
+    // Usuń wszystkie wpisy gdzie sourcePath === filePath
     for (const [key, entries] of this.index) {
       const filtered = entries.filter((e) => e.sourcePath !== filePath);
       if (filtered.length === 0) {
@@ -120,8 +131,6 @@ export class BacklinkIndexService implements IBacklinkIndex {
         this.index.set(key, filtered);
       }
     }
-    // Przetwórz nową zawartość
-    this.processFile(filePath, content);
   }
 
   private processFile(sourcePath: string, content: string): void {

--- a/src/use-cases/backlink-index.ts
+++ b/src/use-cases/backlink-index.ts
@@ -1,0 +1,178 @@
+import path from "node:path";
+import type { Root } from "mdast";
+import type { IBacklinkIndex, BacklinkEntry } from "../domain/interfaces/backlink-index.js";
+import type { MarkdownPipeline } from "./markdown-pipeline.js";
+import { WikilinkResolver } from "./wikilink-resolver.js";
+
+// Klucz mapy to znormalizowana ścieżka: lowercase, bez rozszerzenia .md
+function normalizeKey(filePath: string): string {
+  const withoutExt = filePath.endsWith(".md")
+    ? filePath.slice(0, -3)
+    : filePath;
+  return withoutExt.toLowerCase();
+}
+
+// Numer linii na podstawie pozycji (offset) w tekście
+function lineAtOffset(content: string, offset: number): number {
+  let line = 1;
+  for (let i = 0; i < offset && i < content.length; i++) {
+    if (content[i] === "\n") line++;
+  }
+  return line;
+}
+
+// Fragment kontekstowy ±30 znaków wokół pozycji
+function extractContext(
+  content: string,
+  offset: number,
+  matchLength: number,
+): string {
+  const start = Math.max(0, offset - 30);
+  const end = Math.min(content.length, offset + matchLength + 30);
+  return content.slice(start, end).replace(/\n/g, " ");
+}
+
+// Sprawdza czy URL jest zewnętrzny (http, mailto, itp.)
+function isExternalUrl(url: string): boolean {
+  return /^[a-z]+:\/\//i.test(url) || url.startsWith("mailto:") || url.startsWith("#");
+}
+
+// Rozwiązuje relatywny link markdown na ścieżkę vault-relative
+function resolveRelativeLink(sourcePath: string, url: string): string {
+  const cleanUrl = url.split("#")[0]!.split("?")[0]!;
+  if (!cleanUrl) return "";
+  const dir = path.posix.dirname(sourcePath);
+  return path.posix.normalize(path.posix.join(dir, cleanUrl));
+}
+
+// Rekurencyjne szukanie węzłów danego typu w drzewie AST
+interface LinkNode {
+  type: "link";
+  url: string;
+  position?: { start: { line: number; offset: number } } | undefined;
+}
+
+function findLinkNodes(node: unknown): LinkNode[] {
+  const results: LinkNode[] = [];
+  const walk = (n: unknown): void => {
+    if (typeof n !== "object" || n === null) return;
+    const obj = n as Record<string, unknown>;
+    if (obj["type"] === "link") results.push(n as unknown as LinkNode);
+    if (Array.isArray(obj["children"])) {
+      for (const child of obj["children"]) walk(child);
+    }
+  };
+  walk(node);
+  return results;
+}
+
+// Wyodrębnia wikilinki z pozycjami w tekście
+interface WikilinkMatch {
+  target: string;
+  index: number;
+  fullLength: number;
+}
+
+function extractWikilinksWithPositions(content: string): WikilinkMatch[] {
+  const regex = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g;
+  const results: WikilinkMatch[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(content)) !== null) {
+    results.push({
+      target: match[1]!,
+      index: match.index,
+      fullLength: match[0].length,
+    });
+  }
+  return results;
+}
+
+/**
+ * Usługa indeksująca backlinki w vault.
+ * Przechowuje mapę: znormalizowana ścieżka docelowa → lista wpisów BacklinkEntry.
+ */
+export class BacklinkIndexService implements IBacklinkIndex {
+  private readonly index = new Map<string, BacklinkEntry[]>();
+  private resolver: WikilinkResolver | null = null;
+
+  constructor(private readonly pipeline: MarkdownPipeline) {}
+
+  getBacklinks(targetPath: string): BacklinkEntry[] {
+    const key = normalizeKey(targetPath);
+    return this.index.get(key) ?? [];
+  }
+
+  rebuildIndex(entries: Array<{ path: string; content: string }>): void {
+    this.index.clear();
+    this.resolver = new WikilinkResolver(entries.map((e) => e.path));
+    for (const entry of entries) {
+      this.processFile(entry.path, entry.content);
+    }
+  }
+
+  updateFile(filePath: string, content: string): void {
+    // Usuń stare wpisy dla tego pliku źródłowego
+    for (const [key, entries] of this.index) {
+      const filtered = entries.filter((e) => e.sourcePath !== filePath);
+      if (filtered.length === 0) {
+        this.index.delete(key);
+      } else {
+        this.index.set(key, filtered);
+      }
+    }
+    // Przetwórz nową zawartość
+    this.processFile(filePath, content);
+  }
+
+  private processFile(sourcePath: string, content: string): void {
+    const sourceKey = normalizeKey(sourcePath);
+
+    // Wyodrębnij wikilinki
+    const wikilinks = extractWikilinksWithPositions(content);
+    for (const wl of wikilinks) {
+      const resolved = this.resolver?.resolve(wl.target);
+      const targetPath = resolved ?? `${wl.target}.md`;
+      const targetKey = normalizeKey(targetPath);
+
+      // Pomiń self-linki
+      if (targetKey === sourceKey) continue;
+
+      this.addEntry(targetKey, {
+        sourcePath,
+        lineNumber: lineAtOffset(content, wl.index),
+        context: extractContext(content, wl.index, wl.fullLength),
+        linkType: "wikilink",
+      });
+    }
+
+    // Wyodrębnij linki markdown z AST
+    const tree: Root = this.pipeline.parse(content);
+    const linkNodes = findLinkNodes(tree);
+    for (const node of linkNodes) {
+      if (isExternalUrl(node.url)) continue;
+
+      const resolvedPath = resolveRelativeLink(sourcePath, node.url);
+      if (!resolvedPath) continue;
+
+      const targetKey = normalizeKey(resolvedPath);
+      if (targetKey === sourceKey) continue;
+
+      const offset = node.position?.start.offset ?? 0;
+      this.addEntry(targetKey, {
+        sourcePath,
+        lineNumber: node.position?.start.line ?? 1,
+        context: extractContext(content, offset, node.url.length + 4),
+        linkType: "markdown_link",
+      });
+    }
+  }
+
+  private addEntry(targetKey: string, entry: BacklinkEntry): void {
+    const existing = this.index.get(targetKey);
+    if (existing) {
+      existing.push(entry);
+    } else {
+      this.index.set(targetKey, [entry]);
+    }
+  }
+}

--- a/src/use-cases/batch-edit.test.ts
+++ b/src/use-cases/batch-edit.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { LocalFileSystemAdapter } from "../infrastructure/local-fs-adapter.js";
+import { MarkdownFileRepository } from "../infrastructure/markdown-file-repository.js";
+import { UnifiedDiffService } from "../infrastructure/diff-service.js";
+import { MarkdownPipeline } from "./markdown-pipeline.js";
+import { BatchEditService, type EditOperation } from "./batch-edit.js";
+import { BatchLimitExceededError } from "../domain/errors/index.js";
+
+let tmpDir: string;
+let service: BatchEditService;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "batch-edit-test-"));
+
+  await fs.writeFile(
+    path.join(tmpDir, "note1.md"),
+    "# Note 1\n\n## Section A\n\nContent A.\n",
+  );
+  await fs.writeFile(
+    path.join(tmpDir, "note2.md"),
+    "# Note 2\n\nSome text here.\n",
+  );
+
+  const fsAdapter = await LocalFileSystemAdapter.create(tmpDir);
+  const pipeline = new MarkdownPipeline();
+  const diffService = new UnifiedDiffService();
+  const repo = new MarkdownFileRepository(fsAdapter, pipeline);
+  service = new BatchEditService(fsAdapter, pipeline, diffService, repo);
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("BatchEditService", () => {
+  it("zwraca puste wyniki dla pustej tablicy operacji", async () => {
+    const result = await service.execute({ operations: [] });
+
+    expect(result.totalRequested).toBe(0);
+    expect(result.totalSucceeded).toBe(0);
+    expect(result.totalFailed).toBe(0);
+    expect(result.results).toEqual([]);
+    expect(result.stoppedAtIndex).toBeUndefined();
+  });
+
+  it("wykonuje wszystkie operacje pomyślnie", async () => {
+    const operations: EditOperation[] = [
+      { path: "note1.md", operation: "append", content: "Appended 1.", heading: "Section A", headingDepth: 2 },
+      { path: "note2.md", operation: "append", content: "Appended 2." },
+    ];
+
+    const result = await service.execute({ operations });
+
+    expect(result.totalRequested).toBe(2);
+    expect(result.totalSucceeded).toBe(2);
+    expect(result.totalFailed).toBe(0);
+    expect(result.stoppedAtIndex).toBeUndefined();
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]!.status).toBe("success");
+    expect(result.results[1]!.status).toBe("success");
+
+    // Sprawdź pliki na dysku
+    const content1 = await fs.readFile(path.join(tmpDir, "note1.md"), "utf-8");
+    expect(content1).toContain("Appended 1.");
+    const content2 = await fs.readFile(path.join(tmpDir, "note2.md"), "utf-8");
+    expect(content2).toContain("Appended 2.");
+  });
+
+  it("zatrzymuje się na pierwszym błędzie i zwraca częściowe wyniki", async () => {
+    const operations: EditOperation[] = [
+      { path: "note1.md", operation: "append", content: "OK." },
+      { path: "nonexistent.md", operation: "append", content: "Fail." },
+      { path: "note2.md", operation: "append", content: "Nigdy." },
+    ];
+
+    const result = await service.execute({ operations });
+
+    expect(result.totalRequested).toBe(3);
+    expect(result.totalSucceeded).toBe(1);
+    expect(result.totalFailed).toBe(1);
+    expect(result.stoppedAtIndex).toBe(1);
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]!.status).toBe("success");
+    expect(result.results[1]!.status).toBe("error");
+    expect(result.results[1]!.error).toBeDefined();
+
+    // Trzecia operacja nie powinna być próbowana
+    const content2 = await fs.readFile(path.join(tmpDir, "note2.md"), "utf-8");
+    expect(content2).not.toContain("Nigdy.");
+  });
+
+  it("dryRun generuje diffy bez zapisu na dysk", async () => {
+    const original = await fs.readFile(path.join(tmpDir, "note1.md"), "utf-8");
+
+    const operations: EditOperation[] = [
+      { path: "note1.md", operation: "append", content: "DryRun content." },
+    ];
+
+    const result = await service.execute({ operations, dryRun: true });
+
+    expect(result.totalSucceeded).toBe(1);
+    expect(result.results[0]!.status).toBe("success");
+    expect(result.results[0]!.diff).toBeDefined();
+    expect(result.results[0]!.diff).toContain("DryRun content.");
+
+    // Plik nie powinien się zmienić
+    const afterContent = await fs.readFile(path.join(tmpDir, "note1.md"), "utf-8");
+    expect(afterContent).toBe(original);
+  });
+
+  it("obsługuje mieszane typy operacji", async () => {
+    const operations: EditOperation[] = [
+      { path: "note1.md", operation: "append", content: "Added.", heading: "Section A", headingDepth: 2 },
+      { path: "note2.md", operation: "string_replace", content: "Replaced text.", searchText: "Some text here." },
+    ];
+
+    const result = await service.execute({ operations });
+
+    expect(result.totalSucceeded).toBe(2);
+    expect(result.results).toHaveLength(2);
+
+    const content1 = await fs.readFile(path.join(tmpDir, "note1.md"), "utf-8");
+    expect(content1).toContain("Added.");
+
+    const content2 = await fs.readFile(path.join(tmpDir, "note2.md"), "utf-8");
+    expect(content2).toContain("Replaced text.");
+    expect(content2).not.toContain("Some text here.");
+  });
+
+  it("łapie naruszenie SafePath", async () => {
+    const operations: EditOperation[] = [
+      { path: "../../etc/passwd", operation: "append", content: "Hack." },
+    ];
+
+    const result = await service.execute({ operations });
+
+    expect(result.totalFailed).toBe(1);
+    expect(result.results[0]!.status).toBe("error");
+    expect(result.results[0]!.error).toBeDefined();
+  });
+
+  it("odrzuca operacje przekraczające limit", async () => {
+    const operations: EditOperation[] = Array.from({ length: 51 }, (_, i) => ({
+      path: "note1.md",
+      operation: "append" as const,
+      content: `Op ${i}.`,
+    }));
+
+    await expect(
+      service.execute({ operations }),
+    ).rejects.toThrow(BatchLimitExceededError);
+  });
+});

--- a/src/use-cases/batch-edit.test.ts
+++ b/src/use-cases/batch-edit.test.ts
@@ -36,7 +36,7 @@ afterEach(async () => {
 });
 
 describe("BatchEditService", () => {
-  it("zwraca puste wyniki dla pustej tablicy operacji", async () => {
+  it("returns empty results for an empty operations array", async () => {
     const result = await service.execute({ operations: [] });
 
     expect(result.totalRequested).toBe(0);
@@ -46,7 +46,7 @@ describe("BatchEditService", () => {
     expect(result.stoppedAtIndex).toBeUndefined();
   });
 
-  it("wykonuje wszystkie operacje pomyślnie", async () => {
+  it("executes all operations successfully", async () => {
     const operations: EditOperation[] = [
       { path: "note1.md", operation: "append", content: "Appended 1.", heading: "Section A", headingDepth: 2 },
       { path: "note2.md", operation: "append", content: "Appended 2." },
@@ -62,18 +62,18 @@ describe("BatchEditService", () => {
     expect(result.results[0]!.status).toBe("success");
     expect(result.results[1]!.status).toBe("success");
 
-    // Sprawdź pliki na dysku
+    // Verify files on disk
     const content1 = await fs.readFile(path.join(tmpDir, "note1.md"), "utf-8");
     expect(content1).toContain("Appended 1.");
     const content2 = await fs.readFile(path.join(tmpDir, "note2.md"), "utf-8");
     expect(content2).toContain("Appended 2.");
   });
 
-  it("zatrzymuje się na pierwszym błędzie i zwraca częściowe wyniki", async () => {
+  it("stops on first error and returns partial results", async () => {
     const operations: EditOperation[] = [
       { path: "note1.md", operation: "append", content: "OK." },
       { path: "nonexistent.md", operation: "append", content: "Fail." },
-      { path: "note2.md", operation: "append", content: "Nigdy." },
+      { path: "note2.md", operation: "append", content: "Never." },
     ];
 
     const result = await service.execute({ operations });
@@ -87,12 +87,12 @@ describe("BatchEditService", () => {
     expect(result.results[1]!.status).toBe("error");
     expect(result.results[1]!.error).toBeDefined();
 
-    // Trzecia operacja nie powinna być próbowana
+    // Third operation should not have been attempted
     const content2 = await fs.readFile(path.join(tmpDir, "note2.md"), "utf-8");
-    expect(content2).not.toContain("Nigdy.");
+    expect(content2).not.toContain("Never.");
   });
 
-  it("dryRun generuje diffy bez zapisu na dysk", async () => {
+  it("dryRun generates diffs without writing to disk", async () => {
     const original = await fs.readFile(path.join(tmpDir, "note1.md"), "utf-8");
 
     const operations: EditOperation[] = [
@@ -106,12 +106,12 @@ describe("BatchEditService", () => {
     expect(result.results[0]!.diff).toBeDefined();
     expect(result.results[0]!.diff).toContain("DryRun content.");
 
-    // Plik nie powinien się zmienić
+    // File should not have changed
     const afterContent = await fs.readFile(path.join(tmpDir, "note1.md"), "utf-8");
     expect(afterContent).toBe(original);
   });
 
-  it("obsługuje mieszane typy operacji", async () => {
+  it("handles mixed operation types", async () => {
     const operations: EditOperation[] = [
       { path: "note1.md", operation: "append", content: "Added.", heading: "Section A", headingDepth: 2 },
       { path: "note2.md", operation: "string_replace", content: "Replaced text.", searchText: "Some text here." },
@@ -130,7 +130,7 @@ describe("BatchEditService", () => {
     expect(content2).not.toContain("Some text here.");
   });
 
-  it("łapie naruszenie SafePath", async () => {
+  it("catches SafePath violation", async () => {
     const operations: EditOperation[] = [
       { path: "../../etc/passwd", operation: "append", content: "Hack." },
     ];
@@ -142,7 +142,7 @@ describe("BatchEditService", () => {
     expect(result.results[0]!.error).toBeDefined();
   });
 
-  it("odrzuca operacje przekraczające limit", async () => {
+  it("rejects operations exceeding the limit", async () => {
     const operations: EditOperation[] = Array.from({ length: 51 }, (_, i) => ({
       path: "note1.md",
       operation: "append" as const,

--- a/src/use-cases/batch-edit.ts
+++ b/src/use-cases/batch-edit.ts
@@ -1,0 +1,235 @@
+import yaml from "js-yaml";
+import type { IFileSystemAdapter } from "../domain/interfaces/file-system-adapter.js";
+import type { IDiffService } from "../domain/interfaces/diff-service.js";
+import type { IMarkdownRepository } from "../domain/interfaces/markdown-repository.js";
+import { BatchLimitExceededError } from "../domain/errors/index.js";
+import type { MarkdownPipeline } from "./markdown-pipeline.js";
+import { AstNavigator } from "./ast-navigation.js";
+import { AstPatcher } from "./ast-patcher.js";
+import { FuzzyMatcher } from "./fuzzy-match.js";
+import { FreeformEditor } from "./freeform-editor.js";
+import { DryRunEditor } from "./dry-run-edit.js";
+
+const MAX_OPERATIONS = 50;
+
+/** Pojedyncza operacja edycji w batch. */
+export interface EditOperation {
+  path: string;
+  operation: "append" | "prepend" | "replace" | "line_replace" | "string_replace" | "frontmatter_set";
+  content: string;
+  heading?: string | undefined;
+  headingDepth?: number | undefined;
+  blockId?: string | undefined;
+  startLine?: number | undefined;
+  endLine?: number | undefined;
+  searchText?: string | undefined;
+  replaceAll?: boolean | undefined;
+}
+
+/** Żądanie batch edit. */
+export interface BatchEditRequest {
+  operations: EditOperation[];
+  dryRun?: boolean | undefined;
+}
+
+/** Wynik pojedynczej operacji. */
+export interface BatchEditResult {
+  index: number;
+  path: string;
+  action: string;
+  status: "success" | "error";
+  diff?: string | undefined;
+  error?: string | undefined;
+}
+
+/** Odpowiedź batch edit. */
+export interface BatchEditResponse {
+  results: BatchEditResult[];
+  totalRequested: number;
+  totalSucceeded: number;
+  totalFailed: number;
+  stoppedAtIndex?: number | undefined;
+}
+
+/**
+ * Usługa wykonująca wiele operacji edycji sekwencyjnie.
+ * Zatrzymuje się na pierwszym błędzie.
+ * Deleguje do tych samych use-case'ów co pojedyncze edycje.
+ */
+export class BatchEditService {
+  private readonly dryRunEditor: DryRunEditor;
+
+  constructor(
+    private readonly fsAdapter: IFileSystemAdapter,
+    private readonly pipeline: MarkdownPipeline,
+    diffService: IDiffService,
+    _markdownRepo: IMarkdownRepository,
+  ) {
+    this.dryRunEditor = new DryRunEditor(fsAdapter, diffService);
+  }
+
+  async execute(request: BatchEditRequest): Promise<BatchEditResponse> {
+    const { operations, dryRun } = request;
+
+    if (operations.length > MAX_OPERATIONS) {
+      throw new BatchLimitExceededError(operations.length, MAX_OPERATIONS);
+    }
+
+    if (operations.length === 0) {
+      return {
+        results: [],
+        totalRequested: 0,
+        totalSucceeded: 0,
+        totalFailed: 0,
+      };
+    }
+
+    const results: BatchEditResult[] = [];
+    let totalSucceeded = 0;
+    let totalFailed = 0;
+    let stoppedAtIndex: number | undefined;
+
+    for (let i = 0; i < operations.length; i++) {
+      const op = operations[i]!;
+      try {
+        const editResult = await this.executeSingle(op, dryRun ?? false);
+        results.push({
+          index: i,
+          path: op.path,
+          action: op.operation,
+          status: "success",
+          diff: editResult.diff,
+        });
+        totalSucceeded++;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        results.push({
+          index: i,
+          path: op.path,
+          action: op.operation,
+          status: "error",
+          error: message,
+        });
+        totalFailed++;
+        stoppedAtIndex = i;
+        break;
+      }
+    }
+
+    return {
+      results,
+      totalRequested: operations.length,
+      totalSucceeded,
+      totalFailed,
+      stoppedAtIndex,
+    };
+  }
+
+  // Wykonanie pojedynczej operacji — deleguje do istniejących use-case'ów
+  private async executeSingle(
+    op: EditOperation,
+    dryRun: boolean,
+  ): Promise<{ message: string; diff?: string | undefined }> {
+    const source = await this.fsAdapter.readNote(op.path);
+
+    // ── Freeform: line_replace ────────────────────────────────────
+    if (op.operation === "line_replace") {
+      if (op.startLine === undefined || op.endLine === undefined) {
+        throw new Error("startLine and endLine are required for line_replace");
+      }
+      const newContent = FreeformEditor.lineReplace(
+        source, op.startLine, op.endLine, op.content,
+      );
+      return this.dryRunEditor.execute({
+        path: op.path,
+        oldContent: source,
+        newContent,
+        dryRun,
+        operationLabel: `line_replace lines ${op.startLine}-${op.endLine}`,
+      });
+    }
+
+    // ── Freeform: string_replace ─────────────────────────────────
+    if (op.operation === "string_replace") {
+      if (!op.searchText) {
+        throw new Error("searchText is required for string_replace");
+      }
+      const newContent = FreeformEditor.stringReplace(
+        source, op.searchText, op.content, op.replaceAll ?? false,
+      );
+      return this.dryRunEditor.execute({
+        path: op.path,
+        oldContent: source,
+        newContent,
+        dryRun,
+        operationLabel: "string_replace",
+      });
+    }
+
+    // ── Frontmatter ──────────────────────────────────────────────
+    if (op.operation === "frontmatter_set") {
+      const data = JSON.parse(op.content) as Record<string, unknown>;
+      const tree = this.pipeline.parse(source);
+      const yamlNode = tree.children.find((n) => n.type === "yaml");
+
+      if (yamlNode && yamlNode.type === "yaml") {
+        const existing = yaml.load(yamlNode.value);
+        const merged = Object.assign(
+          {},
+          typeof existing === "object" && existing !== null ? existing : {},
+          data,
+        );
+        yamlNode.value = yaml.dump(merged).trimEnd();
+      } else {
+        tree.children.unshift({
+          type: "yaml",
+          value: yaml.dump(data).trimEnd(),
+        });
+      }
+
+      const newContent = this.pipeline.stringify(tree);
+      return this.dryRunEditor.execute({
+        path: op.path,
+        oldContent: source,
+        newContent,
+        dryRun,
+        operationLabel: "frontmatter_set",
+      });
+    }
+
+    // ── Operacje AST (append / prepend / replace) ────────────────
+    const tree = this.pipeline.parse(source);
+
+    let target: Parameters<typeof AstPatcher.apply>[1]["target"];
+    if (op.blockId) {
+      target = { blockId: op.blockId };
+    } else if (op.heading) {
+      const depth = op.headingDepth ?? 2;
+      const allHeadings = AstNavigator.findAllHeadings(tree);
+      const candidates = allHeadings
+        .filter((h) => h.depth === depth)
+        .map((h) => h.title);
+      if (candidates.length > 0) {
+        const matched = FuzzyMatcher.bestMatch(op.heading, candidates, 0.6);
+        target = matched
+          ? { heading: matched.match, depth }
+          : { heading: op.heading, depth };
+      } else {
+        target = { heading: op.heading, depth };
+      }
+    } else {
+      target = "document";
+    }
+
+    AstPatcher.apply(tree, { type: op.operation, target, content: op.content }, this.pipeline);
+    const newContent = this.pipeline.stringify(tree);
+
+    return this.dryRunEditor.execute({
+      path: op.path,
+      oldContent: source,
+      newContent,
+      dryRun,
+      operationLabel: op.operation,
+    });
+  }
+}

--- a/src/use-cases/batch-edit.ts
+++ b/src/use-cases/batch-edit.ts
@@ -26,13 +26,13 @@ export interface EditOperation {
   replaceAll?: boolean | undefined;
 }
 
-/** Żądanie batch edit. */
+/** Batch edit request. */
 export interface BatchEditRequest {
   operations: EditOperation[];
   dryRun?: boolean | undefined;
 }
 
-/** Wynik pojedynczej operacji. */
+/** Result of a single operation. */
 export interface BatchEditResult {
   index: number;
   path: string;
@@ -42,7 +42,7 @@ export interface BatchEditResult {
   error?: string | undefined;
 }
 
-/** Odpowiedź batch edit. */
+/** Batch edit response. */
 export interface BatchEditResponse {
   results: BatchEditResult[];
   totalRequested: number;
@@ -52,9 +52,9 @@ export interface BatchEditResponse {
 }
 
 /**
- * Usługa wykonująca wiele operacji edycji sekwencyjnie.
- * Zatrzymuje się na pierwszym błędzie.
- * Deleguje do tych samych use-case'ów co pojedyncze edycje.
+ * Service that executes multiple edit operations sequentially.
+ * Stops on first error.
+ * Delegates to the same use cases as single edits.
  */
 export class BatchEditService {
   private readonly dryRunEditor: DryRunEditor;
@@ -125,7 +125,7 @@ export class BatchEditService {
     };
   }
 
-  // Wykonanie pojedynczej operacji — deleguje do istniejących use-case'ów
+  // Execute a single operation — delegates to existing use cases
   private async executeSingle(
     op: EditOperation,
     dryRun: boolean,

--- a/src/use-cases/vault-indexer.test.ts
+++ b/src/use-cases/vault-indexer.test.ts
@@ -104,7 +104,7 @@ describe("VaultIndexer", () => {
   });
 
   describe("onFileIndexed callback", () => {
-    it("wywołuje callback po pomyślnym zaindeksowaniu pliku", async () => {
+    it("invokes callback after successfully indexing a file", async () => {
       const calls: Array<{ path: string; content: string }> = [];
       indexer.setOnFileIndexed((relPath, content) => {
         calls.push({ path: relPath, content });
@@ -121,7 +121,7 @@ describe("VaultIndexer", () => {
       expect(calls[0]!.content).toContain("Test content.");
     });
 
-    it("wywołuje callback onFileRemoved po usunięciu pliku", async () => {
+    it("invokes onFileRemoved callback after removing a file", async () => {
       const removedPaths: string[] = [];
       indexer.setOnFileRemoved((relPath) => {
         removedPaths.push(relPath);

--- a/src/use-cases/vault-indexer.test.ts
+++ b/src/use-cases/vault-indexer.test.ts
@@ -103,6 +103,41 @@ describe("VaultIndexer", () => {
     });
   });
 
+  describe("onFileIndexed callback", () => {
+    it("wywołuje callback po pomyślnym zaindeksowaniu pliku", async () => {
+      const calls: Array<{ path: string; content: string }> = [];
+      indexer.setOnFileIndexed((relPath, content) => {
+        calls.push({ path: relPath, content });
+      });
+
+      await fs.writeFile(
+        path.join(tmpDir, "cb.md"),
+        "# Callback\n\nTest content.\n",
+      );
+      await indexer.indexFile("cb.md");
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.path).toBe("cb.md");
+      expect(calls[0]!.content).toContain("Test content.");
+    });
+
+    it("wywołuje callback onFileRemoved po usunięciu pliku", async () => {
+      const removedPaths: string[] = [];
+      indexer.setOnFileRemoved((relPath) => {
+        removedPaths.push(relPath);
+      });
+
+      await fs.writeFile(
+        path.join(tmpDir, "rm.md"),
+        "# Remove me\n",
+      );
+      await indexer.indexFile("rm.md");
+      await indexer.removeFile("rm.md");
+
+      expect(removedPaths).toEqual(["rm.md"]);
+    });
+  });
+
   describe("removeFile", () => {
     it("removes a deleted note from the vector store", async () => {
       await fs.writeFile(

--- a/src/use-cases/vault-indexer.ts
+++ b/src/use-cases/vault-indexer.ts
@@ -31,6 +31,12 @@ export class VaultIndexer {
   private watcher: FSWatcher | null = null;
 
   /** Set of vault-relative paths pending indexing. */
+  /** Callback wywoływany po pomyślnym zaindeksowaniu pliku. */
+  private onFileIndexedCb?: (relativePath: string, content: string) => void;
+  /** Callback wywoływany po usunięciu pliku z indeksu. */
+  private onFileRemovedCb?: (relativePath: string) => void;
+
+  /** Set of vault-relative paths pending indexing. */
   private readonly queue = new Set<string>();
   /** Debounce timers keyed by relative path. */
   private readonly debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -44,6 +50,16 @@ export class VaultIndexer {
     this.store = store;
     this.embedder = embedder;
     this.chunker = new MarkdownChunker(new MarkdownPipeline());
+  }
+
+  /** Rejestruje callback wywoływany po pomyślnym zaindeksowaniu pliku. */
+  setOnFileIndexed(cb: (relativePath: string, content: string) => void): void {
+    this.onFileIndexedCb = cb;
+  }
+
+  /** Rejestruje callback wywoływany po usunięciu pliku z indeksu. */
+  setOnFileRemoved(cb: (relativePath: string) => void): void {
+    this.onFileRemovedCb = cb;
   }
 
   /** Number of files currently in the offline queue. */
@@ -75,10 +91,14 @@ export class VaultIndexer {
     }
 
     await this.store.upsert({ docPath: relativePath, chunks: vectorChunks });
+
+    // Powiadom callback po pomyślnym zaindeksowaniu
+    this.onFileIndexedCb?.(relativePath, content);
   }
 
   async removeFile(relativePath: string): Promise<void> {
     await this.store.delete(relativePath);
+    this.onFileRemovedCb?.(relativePath);
   }
 
   // ── Bulk indexing ──────────────────────────────────────────────

--- a/src/use-cases/vault-indexer.ts
+++ b/src/use-cases/vault-indexer.ts
@@ -31,9 +31,9 @@ export class VaultIndexer {
   private watcher: FSWatcher | null = null;
 
   /** Set of vault-relative paths pending indexing. */
-  /** Callback wywoływany po pomyślnym zaindeksowaniu pliku. */
+  /** Callback invoked after a file is successfully indexed. */
   private onFileIndexedCb?: (relativePath: string, content: string) => void;
-  /** Callback wywoływany po usunięciu pliku z indeksu. */
+  /** Callback invoked after a file is removed from the index. */
   private onFileRemovedCb?: (relativePath: string) => void;
 
   /** Set of vault-relative paths pending indexing. */
@@ -52,12 +52,12 @@ export class VaultIndexer {
     this.chunker = new MarkdownChunker(new MarkdownPipeline());
   }
 
-  /** Rejestruje callback wywoływany po pomyślnym zaindeksowaniu pliku. */
+  /** Registers a callback invoked after a file is successfully indexed. */
   setOnFileIndexed(cb: (relativePath: string, content: string) => void): void {
     this.onFileIndexedCb = cb;
   }
 
-  /** Rejestruje callback wywoływany po usunięciu pliku z indeksu. */
+  /** Registers a callback invoked after a file is removed from the index. */
   setOnFileRemoved(cb: (relativePath: string) => void): void {
     this.onFileRemovedCb = cb;
   }
@@ -92,7 +92,7 @@ export class VaultIndexer {
 
     await this.store.upsert({ docPath: relativePath, chunks: vectorChunks });
 
-    // Powiadom callback po pomyślnym zaindeksowaniu
+    // Notify callback after successful indexing
     this.onFileIndexedCb?.(relativePath, content);
   }
 

--- a/src/use-cases/vault-overview.test.ts
+++ b/src/use-cases/vault-overview.test.ts
@@ -16,7 +16,7 @@ afterEach(async () => {
 });
 
 describe("VaultOverviewService", () => {
-  it("zwraca pusty wynik dla pustego vault", async () => {
+  it("returns empty result for an empty vault", async () => {
     const adapter = await LocalFileSystemAdapter.create(tmpDir);
     const service = new VaultOverviewService(adapter);
 
@@ -26,7 +26,7 @@ describe("VaultOverviewService", () => {
     expect(result.folders).toEqual([]);
   });
 
-  it("zlicza pliki w płaskim vault", async () => {
+  it("counts files in a flat vault", async () => {
     await fs.writeFile(path.join(tmpDir, "a.md"), "# A\n");
     await fs.writeFile(path.join(tmpDir, "b.md"), "# B\n");
     await fs.writeFile(path.join(tmpDir, "c.md"), "# C\n");
@@ -42,8 +42,8 @@ describe("VaultOverviewService", () => {
     expect(result.folders[0]!.fileCount).toBe(3);
   });
 
-  it("buduje drzewo i zatrzymuje się na limicie głębokości", async () => {
-    // Głębokość: 1/2/3/4 — przy maxDepth=3 folder poziomu 4 nie powinien się pojawić
+  it("builds tree and stops at depth limit", async () => {
+    // Depth: 1/2/3/4 — at maxDepth=3 the level 4 folder should not appear
     await fs.mkdir(path.join(tmpDir, "l1/l2/l3/l4"), { recursive: true });
     await fs.writeFile(path.join(tmpDir, "l1/a.md"), "# A\n");
     await fs.writeFile(path.join(tmpDir, "l1/l2/b.md"), "# B\n");
@@ -57,31 +57,31 @@ describe("VaultOverviewService", () => {
 
     expect(result.totalFiles).toBe(4);
 
-    // l1 jest na poziomie 1
+    // l1 is at level 1
     const l1 = result.folders.find((f) => f.path === "l1");
     expect(l1).toBeDefined();
     expect(l1!.fileCount).toBe(1);
 
-    // l1/l2 na poziomie 2
+    // l1/l2 at level 2
     const l2 = l1!.children.find((f) => f.path === "l1/l2");
     expect(l2).toBeDefined();
     expect(l2!.fileCount).toBe(1);
 
-    // l1/l2/l3 na poziomie 3
+    // l1/l2/l3 at level 3
     const l3 = l2!.children.find((f) => f.path === "l1/l2/l3");
     expect(l3).toBeDefined();
     expect(l3!.fileCount).toBe(1);
 
-    // l1/l2/l3/l4 na poziomie 4 — NIE powinien być widoczny
+    // l1/l2/l3/l4 at level 4 — should NOT be visible
     expect(l3!.children).toHaveLength(0);
   });
 
-  it("lastModified wskazuje na najnowszy plik w katalogu", async () => {
+  it("lastModified points to the newest file in the directory", async () => {
     await fs.mkdir(path.join(tmpDir, "notes"), { recursive: true });
     await fs.writeFile(path.join(tmpDir, "notes/old.md"), "# Old\n");
     await fs.writeFile(path.join(tmpDir, "notes/new.md"), "# New\n");
 
-    // Ustaw różne daty modyfikacji
+    // Set different modification dates
     const oldDate = new Date("2024-01-01T00:00:00Z");
     const newDate = new Date("2025-06-15T12:00:00Z");
     await fs.utimes(path.join(tmpDir, "notes/old.md"), oldDate, oldDate);
@@ -97,7 +97,7 @@ describe("VaultOverviewService", () => {
     expect(notesFolder!.lastModified).toBe(newDate.toISOString());
   });
 
-  it("pomija ukryte katalogi i pliki nie-md", async () => {
+  it("skips hidden directories and non-md files", async () => {
     await fs.mkdir(path.join(tmpDir, ".obsidian"), { recursive: true });
     await fs.mkdir(path.join(tmpDir, ".git"), { recursive: true });
     await fs.mkdir(path.join(tmpDir, "node_modules/pkg"), { recursive: true });
@@ -107,7 +107,7 @@ describe("VaultOverviewService", () => {
     await fs.writeFile(path.join(tmpDir, ".git/config.md"), "hidden");
     await fs.writeFile(path.join(tmpDir, "node_modules/pkg/readme.md"), "hidden");
     await fs.writeFile(path.join(tmpDir, "notes/visible.md"), "# Visible\n");
-    await fs.writeFile(path.join(tmpDir, "image.png"), "binary"); // nie-md
+    await fs.writeFile(path.join(tmpDir, "image.png"), "binary"); // non-md
 
     const adapter = await LocalFileSystemAdapter.create(tmpDir);
     const service = new VaultOverviewService(adapter);
@@ -118,7 +118,7 @@ describe("VaultOverviewService", () => {
     expect(result.folders).toHaveLength(1);
     expect(result.folders[0]!.path).toBe("notes");
 
-    // Żaden ukryty katalog nie powinien się pojawić
+    // No hidden directory should appear
     const allPaths = flattenPaths(result.folders);
     expect(allPaths).not.toContain(".obsidian");
     expect(allPaths).not.toContain(".git");
@@ -127,7 +127,7 @@ describe("VaultOverviewService", () => {
   });
 });
 
-/** Pomocnik do zbierania wszystkich ścieżek z drzewa. */
+/** Helper to collect all paths from the tree. */
 function flattenPaths(folders: Array<{ path: string; children: Array<{ path: string; children: unknown[] }> }>): string[] {
   const result: string[] = [];
   for (const f of folders) {

--- a/src/use-cases/vault-overview.test.ts
+++ b/src/use-cases/vault-overview.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { LocalFileSystemAdapter } from "../infrastructure/local-fs-adapter.js";
+import { VaultOverviewService } from "./vault-overview.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "overview-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("VaultOverviewService", () => {
+  it("zwraca pusty wynik dla pustego vault", async () => {
+    const adapter = await LocalFileSystemAdapter.create(tmpDir);
+    const service = new VaultOverviewService(adapter);
+
+    const result = await service.getOverview();
+
+    expect(result.totalFiles).toBe(0);
+    expect(result.folders).toEqual([]);
+  });
+
+  it("zlicza pliki w płaskim vault", async () => {
+    await fs.writeFile(path.join(tmpDir, "a.md"), "# A\n");
+    await fs.writeFile(path.join(tmpDir, "b.md"), "# B\n");
+    await fs.writeFile(path.join(tmpDir, "c.md"), "# C\n");
+
+    const adapter = await LocalFileSystemAdapter.create(tmpDir);
+    const service = new VaultOverviewService(adapter);
+
+    const result = await service.getOverview();
+
+    expect(result.totalFiles).toBe(3);
+    expect(result.folders).toHaveLength(1);
+    expect(result.folders[0]!.path).toBe(".");
+    expect(result.folders[0]!.fileCount).toBe(3);
+  });
+
+  it("buduje drzewo i zatrzymuje się na limicie głębokości", async () => {
+    // Głębokość: 1/2/3/4 — przy maxDepth=3 folder poziomu 4 nie powinien się pojawić
+    await fs.mkdir(path.join(tmpDir, "l1/l2/l3/l4"), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "l1/a.md"), "# A\n");
+    await fs.writeFile(path.join(tmpDir, "l1/l2/b.md"), "# B\n");
+    await fs.writeFile(path.join(tmpDir, "l1/l2/l3/c.md"), "# C\n");
+    await fs.writeFile(path.join(tmpDir, "l1/l2/l3/l4/d.md"), "# D\n");
+
+    const adapter = await LocalFileSystemAdapter.create(tmpDir);
+    const service = new VaultOverviewService(adapter);
+
+    const result = await service.getOverview(3);
+
+    expect(result.totalFiles).toBe(4);
+
+    // l1 jest na poziomie 1
+    const l1 = result.folders.find((f) => f.path === "l1");
+    expect(l1).toBeDefined();
+    expect(l1!.fileCount).toBe(1);
+
+    // l1/l2 na poziomie 2
+    const l2 = l1!.children.find((f) => f.path === "l1/l2");
+    expect(l2).toBeDefined();
+    expect(l2!.fileCount).toBe(1);
+
+    // l1/l2/l3 na poziomie 3
+    const l3 = l2!.children.find((f) => f.path === "l1/l2/l3");
+    expect(l3).toBeDefined();
+    expect(l3!.fileCount).toBe(1);
+
+    // l1/l2/l3/l4 na poziomie 4 — NIE powinien być widoczny
+    expect(l3!.children).toHaveLength(0);
+  });
+
+  it("lastModified wskazuje na najnowszy plik w katalogu", async () => {
+    await fs.mkdir(path.join(tmpDir, "notes"), { recursive: true });
+    await fs.writeFile(path.join(tmpDir, "notes/old.md"), "# Old\n");
+    await fs.writeFile(path.join(tmpDir, "notes/new.md"), "# New\n");
+
+    // Ustaw różne daty modyfikacji
+    const oldDate = new Date("2024-01-01T00:00:00Z");
+    const newDate = new Date("2025-06-15T12:00:00Z");
+    await fs.utimes(path.join(tmpDir, "notes/old.md"), oldDate, oldDate);
+    await fs.utimes(path.join(tmpDir, "notes/new.md"), newDate, newDate);
+
+    const adapter = await LocalFileSystemAdapter.create(tmpDir);
+    const service = new VaultOverviewService(adapter);
+
+    const result = await service.getOverview();
+    const notesFolder = result.folders.find((f) => f.path === "notes");
+
+    expect(notesFolder).toBeDefined();
+    expect(notesFolder!.lastModified).toBe(newDate.toISOString());
+  });
+
+  it("pomija ukryte katalogi i pliki nie-md", async () => {
+    await fs.mkdir(path.join(tmpDir, ".obsidian"), { recursive: true });
+    await fs.mkdir(path.join(tmpDir, ".git"), { recursive: true });
+    await fs.mkdir(path.join(tmpDir, "node_modules/pkg"), { recursive: true });
+    await fs.mkdir(path.join(tmpDir, "notes"), { recursive: true });
+
+    await fs.writeFile(path.join(tmpDir, ".obsidian/workspace.md"), "hidden");
+    await fs.writeFile(path.join(tmpDir, ".git/config.md"), "hidden");
+    await fs.writeFile(path.join(tmpDir, "node_modules/pkg/readme.md"), "hidden");
+    await fs.writeFile(path.join(tmpDir, "notes/visible.md"), "# Visible\n");
+    await fs.writeFile(path.join(tmpDir, "image.png"), "binary"); // nie-md
+
+    const adapter = await LocalFileSystemAdapter.create(tmpDir);
+    const service = new VaultOverviewService(adapter);
+
+    const result = await service.getOverview();
+
+    expect(result.totalFiles).toBe(1);
+    expect(result.folders).toHaveLength(1);
+    expect(result.folders[0]!.path).toBe("notes");
+
+    // Żaden ukryty katalog nie powinien się pojawić
+    const allPaths = flattenPaths(result.folders);
+    expect(allPaths).not.toContain(".obsidian");
+    expect(allPaths).not.toContain(".git");
+    expect(allPaths).not.toContain("node_modules");
+    expect(allPaths).not.toContain("node_modules/pkg");
+  });
+});
+
+/** Pomocnik do zbierania wszystkich ścieżek z drzewa. */
+function flattenPaths(folders: Array<{ path: string; children: Array<{ path: string; children: unknown[] }> }>): string[] {
+  const result: string[] = [];
+  for (const f of folders) {
+    result.push(f.path);
+    result.push(...flattenPaths(f.children as typeof folders));
+  }
+  return result;
+}

--- a/src/use-cases/vault-overview.ts
+++ b/src/use-cases/vault-overview.ts
@@ -5,7 +5,7 @@ import type {
   FolderSummary,
 } from "../domain/interfaces/vault-overview-service.js";
 
-// Wzorce katalogów do pominięcia
+// Directory patterns to skip
 const HIDDEN_SEGMENT_RE = /^\./;
 const IGNORED_SEGMENTS = new Set(["node_modules"]);
 
@@ -17,8 +17,8 @@ function isHiddenPath(filePath: string): boolean {
 }
 
 /**
- * Usługa budująca przegląd struktury vault.
- * Korzysta z IFileSystemAdapter do odczytu listy plików i metadanych.
+ * Service that builds an overview of the vault structure.
+ * Uses IFileSystemAdapter to read file lists and metadata.
  */
 export class VaultOverviewService implements IVaultOverviewService {
   constructor(private readonly fsAdapter: IFileSystemAdapter) {}
@@ -27,14 +27,14 @@ export class VaultOverviewService implements IVaultOverviewService {
     const depth = maxDepth ?? 3;
     const allFiles = await this.fsAdapter.listNotes();
 
-    // Odfiltruj pliki z ukrytych katalogów
+    // Filter out files from hidden directories
     const files = allFiles.filter((f) => !isHiddenPath(f));
 
     if (files.length === 0) {
       return { totalFiles: 0, folders: [] };
     }
 
-    // Pobierz daty modyfikacji wszystkich plików
+    // Fetch modification dates for all files
     const statsMap = new Map<string, string>();
     await Promise.all(
       files.map(async (f) => {
@@ -43,7 +43,7 @@ export class VaultOverviewService implements IVaultOverviewService {
       }),
     );
 
-    // Pogrupuj pliki po katalogu nadrzędnym
+    // Group files by parent directory
     const dirFiles = new Map<string, string[]>();
     for (const file of files) {
       const parts = file.split("/");
@@ -52,7 +52,7 @@ export class VaultOverviewService implements IVaultOverviewService {
       dirFiles.get(dir)!.push(file);
     }
 
-    // Zbierz wszystkie unikalne ścieżki katalogów (w granicach głębokości)
+    // Collect all unique directory paths (within depth limit)
     const allDirs = new Set<string>();
     for (const file of files) {
       const parts = file.split("/");
@@ -68,7 +68,7 @@ export class VaultOverviewService implements IVaultOverviewService {
       }
     }
 
-    // Zbuduj obiekty FolderSummary
+    // Build FolderSummary objects
     const folderMap = new Map<string, FolderSummary>();
     for (const dir of allDirs) {
       const directFiles = dirFiles.get(dir) ?? [];
@@ -88,7 +88,7 @@ export class VaultOverviewService implements IVaultOverviewService {
       });
     }
 
-    // Zbuduj drzewo — przypisz dzieci do rodziców
+    // Build tree — assign children to parents
     const roots: FolderSummary[] = [];
     for (const [dirPath, summary] of folderMap) {
       if (dirPath === ".") {

--- a/src/use-cases/vault-overview.ts
+++ b/src/use-cases/vault-overview.ts
@@ -1,0 +1,122 @@
+import type { IFileSystemAdapter } from "../domain/interfaces/file-system-adapter.js";
+import type {
+  IVaultOverviewService,
+  VaultOverview,
+  FolderSummary,
+} from "../domain/interfaces/vault-overview-service.js";
+
+// Wzorce katalogów do pominięcia
+const HIDDEN_SEGMENT_RE = /^\./;
+const IGNORED_SEGMENTS = new Set(["node_modules"]);
+
+function isHiddenPath(filePath: string): boolean {
+  const segments = filePath.split("/");
+  return segments.some(
+    (seg) => HIDDEN_SEGMENT_RE.test(seg) || IGNORED_SEGMENTS.has(seg),
+  );
+}
+
+/**
+ * Usługa budująca przegląd struktury vault.
+ * Korzysta z IFileSystemAdapter do odczytu listy plików i metadanych.
+ */
+export class VaultOverviewService implements IVaultOverviewService {
+  constructor(private readonly fsAdapter: IFileSystemAdapter) {}
+
+  async getOverview(maxDepth?: number): Promise<VaultOverview> {
+    const depth = maxDepth ?? 3;
+    const allFiles = await this.fsAdapter.listNotes();
+
+    // Odfiltruj pliki z ukrytych katalogów
+    const files = allFiles.filter((f) => !isHiddenPath(f));
+
+    if (files.length === 0) {
+      return { totalFiles: 0, folders: [] };
+    }
+
+    // Pobierz daty modyfikacji wszystkich plików
+    const statsMap = new Map<string, string>();
+    await Promise.all(
+      files.map(async (f) => {
+        const stat = await this.fsAdapter.stat(f);
+        statsMap.set(f, stat.modifiedAt);
+      }),
+    );
+
+    // Pogrupuj pliki po katalogu nadrzędnym
+    const dirFiles = new Map<string, string[]>();
+    for (const file of files) {
+      const parts = file.split("/");
+      const dir = parts.length === 1 ? "." : parts.slice(0, -1).join("/");
+      if (!dirFiles.has(dir)) dirFiles.set(dir, []);
+      dirFiles.get(dir)!.push(file);
+    }
+
+    // Zbierz wszystkie unikalne ścieżki katalogów (w granicach głębokości)
+    const allDirs = new Set<string>();
+    for (const file of files) {
+      const parts = file.split("/");
+      if (parts.length === 1) {
+        allDirs.add(".");
+      }
+      for (let i = 1; i < parts.length; i++) {
+        const dirPath = parts.slice(0, i).join("/");
+        const dirDepth = i;
+        if (dirDepth <= depth) {
+          allDirs.add(dirPath);
+        }
+      }
+    }
+
+    // Zbuduj obiekty FolderSummary
+    const folderMap = new Map<string, FolderSummary>();
+    for (const dir of allDirs) {
+      const directFiles = dirFiles.get(dir) ?? [];
+      const lastModified =
+        directFiles.length > 0
+          ? directFiles
+              .map((f) => statsMap.get(f)!)
+              .sort()
+              .at(-1)!
+          : "";
+
+      folderMap.set(dir, {
+        path: dir,
+        fileCount: directFiles.length,
+        lastModified,
+        children: [],
+      });
+    }
+
+    // Zbuduj drzewo — przypisz dzieci do rodziców
+    const roots: FolderSummary[] = [];
+    for (const [dirPath, summary] of folderMap) {
+      if (dirPath === ".") {
+        roots.push(summary);
+        continue;
+      }
+      const parentSegments = dirPath.split("/");
+      parentSegments.pop();
+      const parentPath =
+        parentSegments.length === 0 ? "." : parentSegments.join("/");
+      const parent = folderMap.get(parentPath);
+      if (parent) {
+        parent.children.push(summary);
+      } else {
+        roots.push(summary);
+      }
+    }
+
+    // Sortuj katalogi alfabetycznie (rekurencyjnie)
+    sortFolders(roots);
+
+    return { totalFiles: files.length, folders: roots };
+  }
+}
+
+function sortFolders(folders: FolderSummary[]): void {
+  folders.sort((a, b) => a.path.localeCompare(b.path));
+  for (const f of folders) {
+    sortFolders(f.children);
+  }
+}


### PR DESCRIPTION
  Add three new subsystems to the MCP server and wire them together
  so that all indexes stay consistent across every write operation.

  Vault overview (system.overview):
  - Recursive folder tree with file counts and last-modified dates
  - Configurable maxDepth parameter

  Batch edit (edit tool, batch mode):
  - Apply up to 50 edit operations in a single call
  - Sequential execution, stops on first error, supports dryRun
  - operations array alongside existing single-edit interface

  Backlink index (view.backlinks):
  - Find all notes linking to a given path (wikilinks + markdown links)
  - WikilinkResolver for shortest-path filename resolution
  - Line numbers and context snippets for each backlink

  Live index synchronization:
  - vault.create/update/delete/create_from_template update both
    backlink and vector indexes immediately after write
  - All edit operations (append, prepend, replace, line_replace,
    string_replace, frontmatter_set, batch) sync backlink index
    synchronously; vector index updates run in background
  - system.reindex now actually triggers full re-indexing instead
    of returning a no-op message
  - VaultIndexer exposes onFileIndexed/onFileRemoved callbacks so
    the chokidar watcher propagates changes to the backlink index
  - BacklinkIndexService.removeFile() for clean deletion handling
  - system.status includes backlinkIndexSize for observability

  New domain types: IBacklinkIndex, IVaultOverviewService,
  BatchEditTooManyOpsError, BatchEditPartialError

  349 tests (7 new), zero lint errors.