### PR TITLE
fix: add startup health checks and configuration validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ All file operations route through `SafePath` value object — prevents path trav
 | `OLLAMA_MODEL` | `nomic-embed-text` | Ollama embedding model name |
 | `OLLAMA_DIMENSIONS` | `768` | Ollama embedding vector dimensions |
 | `VECTOR_STORE_URL` | *(unset)* | Set to use Qdrant (e.g. `http://localhost:6333`). If unset, local persisted flat store is used. |
+| `VECTOR_STORE_RESET` | `false` | Set to `true` to auto-delete a mismatched vector index on startup and rebuild from scratch. |
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ The server selects an embedding provider automatically:
 | `OLLAMA_MODEL` | `nomic-embed-text` | Ollama embedding model name |
 | `OLLAMA_DIMENSIONS` | `768` | Ollama embedding vector dimensions |
 | `VECTOR_STORE_URL` | *(unset)* | Set to use Qdrant (e.g. `http://localhost:6333`). If unset, local persisted flat store is used. |
+| `VECTOR_STORE_RESET` | `false` | Set to `true` to auto-delete a mismatched vector index on startup and rebuild from scratch. |
 
 > **Note**: When using the default local vector store, a `.markdown_vault_mcp` directory will be created in your vault. It's recommended to add this directory to your `.gitignore`.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,11 @@ import { LocalFileSystemAdapter } from "./infrastructure/local-fs-adapter.js";
 import { createVectorStore } from "./infrastructure/vector-store-factory.js";
 import { OllamaEmbeddingProvider } from "./infrastructure/ollama-embedding.js";
 import { TransformersEmbeddingProvider } from "./infrastructure/transformers-embedding.js";
+import {
+  validateOllama,
+  validateVectorStore,
+  StartupError,
+} from "./infrastructure/startup-checks.js";
 import type { IEmbeddingProvider } from "./domain/interfaces/index.js";
 import { WorkflowStateMachine } from "./use-cases/workflow-state.js";
 import { VaultIndexer } from "./use-cases/vault-indexer.js";
@@ -66,11 +71,37 @@ async function main(): Promise<void> {
     process.env["MCP_TRANSPORT_TYPE"],
   );
   const port = parseInt(process.env["PORT"] ?? "3000", 10);
+  const ollamaUrl = process.env["OLLAMA_URL"];
+  const ollamaModel = process.env["OLLAMA_MODEL"] ?? "nomic-embed-text";
+  const qdrantUrl = process.env["VECTOR_STORE_URL"];
+  const qdrantCollection =
+    process.env["VECTOR_STORE_COLLECTION"] ?? "markdown_vault";
+  const allowReset = process.env["VECTOR_STORE_RESET"] === "true";
 
   // Shared dependencies (reused across all client connections)
   const fsAdapter = await LocalFileSystemAdapter.create(vaultRoot);
+
+  // ── Startup health checks ──────────────────────────────────────
+  if (ollamaUrl !== undefined) {
+    await validateOllama(ollamaUrl, ollamaModel);
+  }
+
   const embedder = await createEmbeddingProvider();
-  const vectorStore = await createVectorStore(vaultRoot, embedder.modelName, embedder.dimensions);
+
+  await validateVectorStore({
+    qdrantUrl,
+    qdrantCollection,
+    vaultPath: vaultRoot,
+    expectedDimensions: embedder.dimensions,
+    expectedModel: embedder.modelName,
+    allowReset,
+  });
+
+  const vectorStore = await createVectorStore(
+    vaultRoot,
+    embedder.modelName,
+    embedder.dimensions,
+  );
 
   // Backlink index — shared across connections
   const backlinkIndex = new BacklinkIndexService(new MarkdownPipeline());
@@ -146,6 +177,11 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  console.error("Fatal:", err);
+  if (err instanceof StartupError) {
+    console.error(`\nStartup check failed: ${err.message}`);
+    console.error(`  → ${err.hint}\n`);
+  } else {
+    console.error("Fatal:", err);
+  }
   process.exit(1);
 });

--- a/src/infrastructure/startup-checks.test.ts
+++ b/src/infrastructure/startup-checks.test.ts
@@ -1,0 +1,443 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+import {
+  validateOllama,
+  validateVectorStore,
+  StartupError,
+} from "./startup-checks.js";
+
+// ── Ollama ──────────────────────────────────────────────────────────
+
+describe("validateOllama", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes when Ollama is reachable and model is pulled (exact name)", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ models: [{ name: "nomic-embed-text" }] }),
+    });
+
+    await expect(
+      validateOllama("http://localhost:11434", "nomic-embed-text"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("passes when model name matches with tag suffix", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        models: [{ name: "nomic-embed-text:latest" }],
+      }),
+    });
+
+    await expect(
+      validateOllama("http://localhost:11434", "nomic-embed-text"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws StartupError when Ollama is unreachable", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const err = await validateOllama(
+      "http://localhost:11434",
+      "nomic-embed-text",
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(StartupError);
+    expect((err as StartupError).message).toMatch(/not reachable/);
+    expect((err as StartupError).hint).toMatch(/ollama serve/);
+  });
+
+  it("throws StartupError when Ollama returns non-OK status", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+    await expect(
+      validateOllama("http://localhost:11434", "nomic-embed-text"),
+    ).rejects.toThrow(StartupError);
+  });
+
+  it("throws StartupError when model is not pulled, lists available models", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        models: [{ name: "llama3:latest" }, { name: "phi3:latest" }],
+      }),
+    });
+
+    const err = await validateOllama(
+      "http://localhost:11434",
+      "nomic-embed-text",
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(StartupError);
+    expect((err as StartupError).message).toMatch(/not pulled/);
+    expect((err as StartupError).hint).toMatch(/ollama pull nomic-embed-text/);
+    expect((err as StartupError).hint).toMatch(/llama3:latest/);
+  });
+
+  it("throws when models list is empty", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ models: [] }),
+    });
+
+    const err = await validateOllama(
+      "http://localhost:11434",
+      "nomic-embed-text",
+    ).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(StartupError);
+    expect((err as StartupError).hint).toMatch(/\(none\)/);
+  });
+
+  it("strips trailing slashes from URL", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        models: [{ name: "nomic-embed-text:latest" }],
+      }),
+    });
+
+    await validateOllama("http://localhost:11434///", "nomic-embed-text");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:11434/api/tags",
+      expect.any(Object),
+    );
+  });
+});
+
+// ── Vector store: Qdrant ────────────────────────────────────────────
+
+describe("validateVectorStore — Qdrant", () => {
+  const mockFetch = vi.fn();
+  const baseOpts = {
+    qdrantUrl: "http://localhost:6333",
+    qdrantCollection: "markdown_vault",
+    vaultPath: "/tmp",
+    expectedDimensions: 384,
+    expectedModel: "all-MiniLM-L6-v2",
+    allowReset: false,
+  };
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes when Qdrant is reachable and collection does not exist", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: { collections: [] } }),
+    });
+
+    await expect(validateVectorStore(baseOpts)).resolves.toBeUndefined();
+  });
+
+  it("passes when collection exists with matching dimensions", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: { collections: [{ name: "markdown_vault" }] },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: {
+            config: { params: { vectors: { size: 384 } } },
+          },
+        }),
+      });
+
+    await expect(validateVectorStore(baseOpts)).resolves.toBeUndefined();
+  });
+
+  it("throws StartupError when Qdrant is unreachable", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const err = await validateVectorStore(baseOpts).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(StartupError);
+    expect((err as StartupError).message).toMatch(/not reachable/);
+  });
+
+  it("throws on dimension mismatch when allowReset=false", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: { collections: [{ name: "markdown_vault" }] },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: {
+            config: { params: { vectors: { size: 768 } } },
+          },
+        }),
+      });
+
+    const err = await validateVectorStore(baseOpts).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(StartupError);
+    expect((err as StartupError).message).toMatch(/vector size 768/);
+    expect((err as StartupError).hint).toMatch(/VECTOR_STORE_RESET=true/);
+  });
+
+  it("deletes collection on dimension mismatch when allowReset=true", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: { collections: [{ name: "markdown_vault" }] },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: {
+            config: { params: { vectors: { size: 768 } } },
+          },
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true });
+
+    await expect(
+      validateVectorStore({ ...baseOpts, allowReset: true }),
+    ).resolves.toBeUndefined();
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    const [deleteUrl, deleteOpts] = mockFetch.mock.calls[2]!;
+    expect(deleteUrl).toBe(
+      "http://localhost:6333/collections/markdown_vault",
+    );
+    expect(deleteOpts).toMatchObject({ method: "DELETE" });
+  });
+
+  it("throws when collection delete fails during reset", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: { collections: [{ name: "markdown_vault" }] },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: {
+            config: { params: { vectors: { size: 768 } } },
+          },
+        }),
+      })
+      .mockResolvedValueOnce({ ok: false, status: 500 });
+
+    await expect(
+      validateVectorStore({ ...baseOpts, allowReset: true }),
+    ).rejects.toThrow(StartupError);
+  });
+});
+
+// ── Vector store: local persisted ───────────────────────────────────
+
+describe("validateVectorStore — local store", () => {
+  let tmpVault: string;
+  const baseOpts = {
+    qdrantCollection: "markdown_vault",
+    expectedDimensions: 384,
+    expectedModel: "all-MiniLM-L6-v2",
+    allowReset: false,
+  };
+
+  beforeEach(async () => {
+    tmpVault = await fs.mkdtemp(
+      path.join(os.tmpdir(), "mcp-test-startup-"),
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpVault, { recursive: true, force: true });
+  });
+
+  function writeIndex(meta: Record<string, unknown>): Promise<void> {
+    const storeDir = path.join(tmpVault, ".markdown_vault_mcp");
+    return fs.mkdir(storeDir, { recursive: true }).then(() =>
+      fs.writeFile(
+        path.join(storeDir, "index.json"),
+        JSON.stringify(meta),
+      ),
+    );
+  }
+
+  it("passes when no index files exist (fresh vault)", async () => {
+    await expect(
+      validateVectorStore({ ...baseOpts, vaultPath: tmpVault }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("passes when index fingerprint matches", async () => {
+    await writeIndex({
+      version: 1,
+      embeddingModel: "all-MiniLM-L6-v2",
+      dimensions: 384,
+      savedAt: new Date().toISOString(),
+      chunks: [],
+    });
+
+    await expect(
+      validateVectorStore({ ...baseOpts, vaultPath: tmpVault }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws on dimension mismatch when allowReset=false", async () => {
+    await writeIndex({
+      version: 1,
+      embeddingModel: "nomic-embed-text",
+      dimensions: 768,
+      chunks: [],
+    });
+
+    const err = await validateVectorStore({
+      ...baseOpts,
+      vaultPath: tmpVault,
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(StartupError);
+    expect((err as StartupError).message).toMatch(/incompatible/);
+    expect((err as StartupError).message).toMatch(/dimensions.*768.*384/);
+    expect((err as StartupError).hint).toMatch(/VECTOR_STORE_RESET=true/);
+  });
+
+  it("throws on model mismatch even when dimensions match", async () => {
+    await writeIndex({
+      version: 1,
+      embeddingModel: "other-model",
+      dimensions: 384,
+      chunks: [],
+    });
+
+    const err = await validateVectorStore({
+      ...baseOpts,
+      vaultPath: tmpVault,
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(StartupError);
+    expect((err as StartupError).message).toMatch(/model.*other-model/);
+  });
+
+  it("deletes index files on dimension mismatch when allowReset=true", async () => {
+    const storeDir = path.join(tmpVault, ".markdown_vault_mcp");
+    await writeIndex({
+      version: 1,
+      embeddingModel: "nomic-embed-text",
+      dimensions: 768,
+      chunks: [],
+    });
+    await fs.writeFile(path.join(storeDir, "vectors.bin"), Buffer.alloc(8));
+
+    await expect(
+      validateVectorStore({
+        ...baseOpts,
+        vaultPath: tmpVault,
+        allowReset: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      fs.access(path.join(storeDir, "index.json")),
+    ).rejects.toThrow();
+    await expect(
+      fs.access(path.join(storeDir, "vectors.bin")),
+    ).rejects.toThrow();
+  });
+
+  it("deletes index files on model mismatch when allowReset=true", async () => {
+    await writeIndex({
+      version: 1,
+      embeddingModel: "other-model",
+      dimensions: 384,
+      chunks: [],
+    });
+
+    await expect(
+      validateVectorStore({
+        ...baseOpts,
+        vaultPath: tmpVault,
+        allowReset: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      fs.access(path.join(tmpVault, ".markdown_vault_mcp", "index.json")),
+    ).rejects.toThrow();
+  });
+
+  it("handles corrupted index.json when allowReset=true", async () => {
+    const storeDir = path.join(tmpVault, ".markdown_vault_mcp");
+    await fs.mkdir(storeDir, { recursive: true });
+    await fs.writeFile(path.join(storeDir, "index.json"), "NOT JSON{{{");
+
+    await expect(
+      validateVectorStore({
+        ...baseOpts,
+        vaultPath: tmpVault,
+        allowReset: true,
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      fs.access(path.join(storeDir, "index.json")),
+    ).rejects.toThrow();
+  });
+
+  it("throws on corrupted index.json when allowReset=false", async () => {
+    const storeDir = path.join(tmpVault, ".markdown_vault_mcp");
+    await fs.mkdir(storeDir, { recursive: true });
+    await fs.writeFile(path.join(storeDir, "index.json"), "NOT JSON{{{");
+
+    await expect(
+      validateVectorStore({ ...baseOpts, vaultPath: tmpVault }),
+    ).rejects.toThrow(StartupError);
+  });
+
+  it("also removes stale .tmp files during reset", async () => {
+    const storeDir = path.join(tmpVault, ".markdown_vault_mcp");
+    await writeIndex({
+      version: 1,
+      embeddingModel: "old",
+      dimensions: 768,
+      chunks: [],
+    });
+    await fs.writeFile(
+      path.join(storeDir, "index.json.tmp"),
+      "stale",
+    );
+    await fs.writeFile(
+      path.join(storeDir, "vectors.bin.tmp"),
+      "stale",
+    );
+
+    await validateVectorStore({
+      ...baseOpts,
+      vaultPath: tmpVault,
+      allowReset: true,
+    });
+
+    await expect(
+      fs.access(path.join(storeDir, "index.json.tmp")),
+    ).rejects.toThrow();
+    await expect(
+      fs.access(path.join(storeDir, "vectors.bin.tmp")),
+    ).rejects.toThrow();
+  });
+});

--- a/src/infrastructure/startup-checks.ts
+++ b/src/infrastructure/startup-checks.ts
@@ -1,0 +1,262 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+export class StartupError extends Error {
+  public readonly hint: string;
+
+  constructor(message: string, hint: string) {
+    super(message);
+    this.name = "StartupError";
+    this.hint = hint;
+  }
+}
+
+// ── Ollama ──────────────────────────────────────────────────────────
+
+export async function validateOllama(
+  ollamaUrl: string,
+  model: string,
+): Promise<void> {
+  const baseUrl = ollamaUrl.replace(/\/+$/, "");
+
+  let response: Response;
+  try {
+    response = await fetch(`${baseUrl}/api/tags`, {
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch {
+    throw new StartupError(
+      `Ollama is not reachable at ${ollamaUrl}`,
+      `Ensure Ollama is running ("ollama serve") or unset OLLAMA_URL to use local embeddings.`,
+    );
+  }
+
+  if (!response.ok) {
+    throw new StartupError(
+      `Ollama returned HTTP ${response.status}`,
+      `Check Ollama health at ${ollamaUrl}. Unset OLLAMA_URL to fall back to local embeddings.`,
+    );
+  }
+
+  const data = (await response.json()) as {
+    models?: Array<{ name: string }>;
+  };
+  const models = data.models ?? [];
+  const found = models.some(
+    (m) => m.name === model || m.name.startsWith(`${model}:`),
+  );
+
+  if (!found) {
+    const available =
+      models.map((m) => m.name).join(", ") || "(none)";
+    throw new StartupError(
+      `Ollama model "${model}" is not pulled`,
+      `Run "ollama pull ${model}" or set OLLAMA_MODEL to one of: ${available}`,
+    );
+  }
+}
+
+// ── Vector store compatibility ──────────────────────────────────────
+
+export interface VectorStoreCheckOptions {
+  qdrantUrl?: string | undefined;
+  qdrantCollection: string;
+  vaultPath: string;
+  expectedDimensions: number;
+  expectedModel: string;
+  allowReset: boolean;
+}
+
+export async function validateVectorStore(
+  opts: VectorStoreCheckOptions,
+): Promise<void> {
+  if (opts.qdrantUrl) {
+    await validateQdrant(
+      opts.qdrantUrl,
+      opts.qdrantCollection,
+      opts.expectedDimensions,
+      opts.allowReset,
+    );
+  } else {
+    await validateLocalStore(
+      opts.vaultPath,
+      opts.expectedDimensions,
+      opts.expectedModel,
+      opts.allowReset,
+    );
+  }
+}
+
+// ── Qdrant ──────────────────────────────────────────────────────────
+
+async function validateQdrant(
+  qdrantUrl: string,
+  collectionName: string,
+  expectedDimensions: number,
+  allowReset: boolean,
+): Promise<void> {
+  const baseUrl = qdrantUrl.replace(/\/+$/, "");
+
+  let collectionsResponse: Response;
+  try {
+    collectionsResponse = await fetch(`${baseUrl}/collections`, {
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch {
+    throw new StartupError(
+      `Qdrant is not reachable at ${qdrantUrl}`,
+      `Ensure Qdrant is running or unset VECTOR_STORE_URL to use local storage.`,
+    );
+  }
+
+  if (!collectionsResponse.ok) {
+    throw new StartupError(
+      `Qdrant returned HTTP ${collectionsResponse.status}`,
+      `Check Qdrant health at ${qdrantUrl}.`,
+    );
+  }
+
+  const collectionsData = (await collectionsResponse.json()) as {
+    result?: { collections?: Array<{ name: string }> };
+  };
+  const collections = collectionsData.result?.collections ?? [];
+  const exists = collections.some((c) => c.name === collectionName);
+
+  if (!exists) return;
+
+  let infoResponse: Response;
+  try {
+    infoResponse = await fetch(
+      `${baseUrl}/collections/${encodeURIComponent(collectionName)}`,
+      { signal: AbortSignal.timeout(5000) },
+    );
+  } catch {
+    throw new StartupError(
+      `Failed to query Qdrant collection "${collectionName}"`,
+      `Check Qdrant health at ${qdrantUrl}.`,
+    );
+  }
+
+  if (!infoResponse.ok) {
+    throw new StartupError(
+      `Qdrant returned HTTP ${infoResponse.status} for collection "${collectionName}"`,
+      `Check Qdrant health at ${qdrantUrl}.`,
+    );
+  }
+
+  const infoData = (await infoResponse.json()) as {
+    result?: {
+      config?: { params?: { vectors?: { size?: number } } };
+    };
+  };
+  const storedSize = infoData.result?.config?.params?.vectors?.size;
+
+  if (storedSize === undefined || storedSize === expectedDimensions) return;
+
+  if (allowReset) {
+    console.error(
+      `[StartupCheck] Qdrant collection "${collectionName}" has dimension ${storedSize} but expected ${expectedDimensions}. Deleting collection (VECTOR_STORE_RESET=true).`,
+    );
+    const deleteResponse = await fetch(
+      `${baseUrl}/collections/${encodeURIComponent(collectionName)}`,
+      { method: "DELETE", signal: AbortSignal.timeout(10_000) },
+    );
+    if (!deleteResponse.ok) {
+      throw new StartupError(
+        `Failed to delete Qdrant collection "${collectionName}" (HTTP ${deleteResponse.status})`,
+        `Manually delete the collection or fix the dimension mismatch.`,
+      );
+    }
+    return;
+  }
+
+  throw new StartupError(
+    `Qdrant collection "${collectionName}" has vector size ${storedSize} but the current embedding provider produces ${expectedDimensions}-dimensional vectors`,
+    `Switch back to the original embedding model, delete the collection manually, or set VECTOR_STORE_RESET=true to auto-rebuild.`,
+  );
+}
+
+// ── Local persisted store ───────────────────────────────────────────
+
+interface LocalIndexMeta {
+  embeddingModel: string;
+  dimensions: number;
+}
+
+async function validateLocalStore(
+  vaultPath: string,
+  expectedDimensions: number,
+  expectedModel: string,
+  allowReset: boolean,
+): Promise<void> {
+  const storeDir = path.join(vaultPath, ".markdown_vault_mcp");
+  const indexFile = path.join(storeDir, "index.json");
+
+  let raw: string;
+  try {
+    raw = await fs.readFile(indexFile, "utf-8");
+  } catch (err: any) {
+    if (err.code === "ENOENT") return;
+    throw new StartupError(
+      `Failed to read local vector index at ${indexFile}: ${err.message}`,
+      `Check file permissions or delete the .markdown_vault_mcp directory.`,
+    );
+  }
+
+  let meta: LocalIndexMeta;
+  try {
+    meta = JSON.parse(raw) as LocalIndexMeta;
+  } catch {
+    if (allowReset) {
+      console.error(
+        `[StartupCheck] Corrupted index at ${indexFile}. Deleting (VECTOR_STORE_RESET=true).`,
+      );
+      await deleteLocalIndex(storeDir);
+      return;
+    }
+    throw new StartupError(
+      `Corrupted vector index at ${indexFile}`,
+      `Delete the .markdown_vault_mcp directory or set VECTOR_STORE_RESET=true.`,
+    );
+  }
+
+  const dimensionMismatch = meta.dimensions !== expectedDimensions;
+  const modelMismatch = meta.embeddingModel !== expectedModel;
+
+  if (!dimensionMismatch && !modelMismatch) return;
+
+  if (allowReset) {
+    const reason = dimensionMismatch
+      ? `dimensions ${meta.dimensions} → ${expectedDimensions}`
+      : `model "${meta.embeddingModel}" → "${expectedModel}"`;
+    console.error(
+      `[StartupCheck] Local index mismatch (${reason}). Deleting (VECTOR_STORE_RESET=true).`,
+    );
+    await deleteLocalIndex(storeDir);
+    return;
+  }
+
+  const details: string[] = [];
+  if (dimensionMismatch) {
+    details.push(
+      `dimensions: stored=${meta.dimensions}, current=${expectedDimensions}`,
+    );
+  }
+  if (modelMismatch) {
+    details.push(
+      `model: stored="${meta.embeddingModel}", current="${expectedModel}"`,
+    );
+  }
+
+  throw new StartupError(
+    `Local vector index is incompatible with current embedding provider (${details.join("; ")})`,
+    `Switch back to the original model, delete the .markdown_vault_mcp directory, or set VECTOR_STORE_RESET=true to auto-rebuild.`,
+  );
+}
+
+async function deleteLocalIndex(storeDir: string): Promise<void> {
+  await fs.rm(path.join(storeDir, "index.json"), { force: true });
+  await fs.rm(path.join(storeDir, "vectors.bin"), { force: true });
+  await fs.rm(path.join(storeDir, "index.json.tmp"), { force: true });
+  await fs.rm(path.join(storeDir, "vectors.bin.tmp"), { force: true });
+}


### PR DESCRIPTION
  Validate external dependencies before accepting MCP connections.
  - Ollama: verify reachability and model availability when OLLAMA_URL is set.
  - Qdrant: verify reachability and dimension compatibility when
    VECTOR_STORE_URL is set.
  - Local store: verify index fingerprint (model + dimensions) matches
    current embedding provider.
  - On failure, print actionable error with hint and exit with code 1.
  - Add VECTOR_STORE_RESET env var to auto-delete mismatched indices
    and rebuild from scratch instead of failing.
  - 22 new unit tests with no live network calls.