### PR TITLE
feat: add optional Bearer token authentication for SSE transport

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ All file operations route through `SafePath` value object — prevents path trav
 | `OLLAMA_DIMENSIONS` | `768` | Ollama embedding vector dimensions |
 | `VECTOR_STORE_URL` | *(unset)* | Set to use Qdrant (e.g. `http://localhost:6333`). If unset, local persisted flat store is used. |
 | `VECTOR_STORE_RESET` | `false` | Set to `true` to auto-delete a mismatched vector index on startup and rebuild from scratch. |
+| `MCP_AUTH_TOKEN` | *(unset)* | Bearer token for SSE transport auth. If set, all SSE endpoints require `Authorization: Bearer <token>`. |
 
 ## Conventions
 

--- a/src/domain/errors/index.ts
+++ b/src/domain/errors/index.ts
@@ -125,6 +125,15 @@ export class BatchLimitExceededError extends DomainError {
   }
 }
 
+// ── Authentication errors ─────────────────────────────────────────
+
+export class AuthenticationError extends DomainError {
+  constructor(detail: string) {
+    super("AUTHENTICATION_FAILED", `Authentication failed: ${detail}`);
+    this.name = "AuthenticationError";
+  }
+}
+
 // ── Workflow / State errors ────────────────────────────────────────
 
 export class StateTransitionError extends DomainError {

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ async function main(): Promise<void> {
     process.env["MCP_TRANSPORT_TYPE"],
   );
   const port = parseInt(process.env["PORT"] ?? "3000", 10);
+  const authToken = process.env["MCP_AUTH_TOKEN"];
   const ollamaUrl = process.env["OLLAMA_URL"];
   const ollamaModel = process.env["OLLAMA_MODEL"] ?? "nomic-embed-text";
   const qdrantUrl = process.env["VECTOR_STORE_URL"];
@@ -156,8 +157,12 @@ async function main(): Promise<void> {
 
   // Connect via selected transport
   console.error(`Transport: ${transportType}`);
+  if (authToken) {
+    console.error("Bearer auth: enabled");
+  }
   const handle = await startTransport(transportType, serverFactory, {
     port,
+    authToken,
   });
 
   // Handle shutdown

--- a/src/presentation/auth-middleware.test.ts
+++ b/src/presentation/auth-middleware.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, afterEach } from "vitest";
+import express from "express";
+import type { AddressInfo } from "node:net";
+import type { Server as HttpServer } from "node:http";
+import { createBearerAuthMiddleware } from "./auth-middleware.js";
+
+function createTestApp(token: string | undefined) {
+  const app = express();
+  const middleware = createBearerAuthMiddleware(token);
+  if (middleware) {
+    app.use(middleware);
+  }
+  app.get("/protected", (_req, res) => {
+    res.json({ ok: true });
+  });
+
+  const httpServer = app.listen(0);
+  const { port } = httpServer.address() as AddressInfo;
+  return { httpServer, port };
+}
+
+describe("createBearerAuthMiddleware", () => {
+  const servers: HttpServer[] = [];
+
+  function setup(token: string | undefined) {
+    const { httpServer, port } = createTestApp(token);
+    servers.push(httpServer);
+    return port;
+  }
+
+  afterEach(async () => {
+    for (const s of servers) {
+      await new Promise<void>((resolve) => s.close(() => resolve()));
+    }
+    servers.length = 0;
+  });
+
+  it("returns null when token is undefined (no auth)", () => {
+    const middleware = createBearerAuthMiddleware(undefined);
+    expect(middleware).toBeNull();
+  });
+
+  it("returns null when token is empty string (no auth)", () => {
+    const middleware = createBearerAuthMiddleware("");
+    expect(middleware).toBeNull();
+  });
+
+  it("allows request with valid Bearer token", async () => {
+    const port = setup("secret-token");
+
+    const res = await fetch(`http://localhost:${port}/protected`, {
+      headers: { Authorization: "Bearer secret-token" },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+  });
+
+  it("rejects request with missing Authorization header", async () => {
+    const port = setup("secret-token");
+
+    const res = await fetch(`http://localhost:${port}/protected`);
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/missing/i);
+  });
+
+  it("rejects request with wrong token", async () => {
+    const port = setup("secret-token");
+
+    const res = await fetch(`http://localhost:${port}/protected`, {
+      headers: { Authorization: "Bearer wrong-token" },
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/invalid/i);
+  });
+
+  it("rejects request with non-Bearer scheme", async () => {
+    const port = setup("secret-token");
+
+    const res = await fetch(`http://localhost:${port}/protected`, {
+      headers: { Authorization: "Basic dXNlcjpwYXNz" },
+    });
+
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/missing/i);
+  });
+
+  it("uses constant-time comparison (no timing leak)", async () => {
+    const port = setup("a".repeat(64));
+
+    const res = await fetch(`http://localhost:${port}/protected`, {
+      headers: { Authorization: "Bearer " + "b".repeat(64) },
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("passes through when no token configured (disabled auth)", async () => {
+    const port = setup(undefined);
+
+    const res = await fetch(`http://localhost:${port}/protected`);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+  });
+});

--- a/src/presentation/auth-middleware.ts
+++ b/src/presentation/auth-middleware.ts
@@ -1,0 +1,34 @@
+import type { RequestHandler } from "express";
+import { timingSafeEqual } from "node:crypto";
+
+export function createBearerAuthMiddleware(
+  token: string | undefined,
+): RequestHandler | null {
+  if (!token) return null;
+
+  const expectedBuffer = Buffer.from(token, "utf-8");
+
+  const middleware: RequestHandler = (req, res, next) => {
+    const header = req.headers["authorization"];
+
+    if (!header || !header.startsWith("Bearer ")) {
+      res.status(401).json({ error: "Missing Bearer token" });
+      return;
+    }
+
+    const provided = header.slice(7);
+    const providedBuffer = Buffer.from(provided, "utf-8");
+
+    if (
+      providedBuffer.length !== expectedBuffer.length ||
+      !timingSafeEqual(providedBuffer, expectedBuffer)
+    ) {
+      res.status(401).json({ error: "Invalid token" });
+      return;
+    }
+
+    next();
+  };
+
+  return middleware;
+}

--- a/src/presentation/transport.test.ts
+++ b/src/presentation/transport.test.ts
@@ -145,3 +145,88 @@ describe("createSseApp", () => {
     expect(res.headers.get("access-control-allow-origin")).toBe("*");
   });
 });
+
+describe("createSseApp with auth", () => {
+  const openServers: HttpServer[] = [];
+
+  afterEach(async () => {
+    for (const s of openServers) {
+      await new Promise<void>((resolve) => s.close(() => resolve()));
+    }
+    openServers.length = 0;
+  });
+
+  function listenWithAuth(token: string) {
+    const serverFactory = createMockServerFactory();
+    const { app, sessions } = createSseApp(serverFactory, {
+      authToken: token,
+    });
+    const httpServer = app.listen(0);
+    openServers.push(httpServer);
+    const { port } = httpServer.address() as AddressInfo;
+    return { sessions, port, serverFactory };
+  }
+
+  it("GET /sse rejects without token when auth is enabled", async () => {
+    const { port } = listenWithAuth("test-token");
+
+    const controller = new AbortController();
+    try {
+      const res = await fetch(`http://localhost:${port}/sse`, {
+        signal: controller.signal,
+      });
+      expect(res.status).toBe(401);
+    } finally {
+      controller.abort();
+    }
+  });
+
+  it("POST /messages rejects without token when auth is enabled", async () => {
+    const { port } = listenWithAuth("test-token");
+
+    const res = await fetch(
+      `http://localhost:${port}/messages?sessionId=abc`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /sse allows with valid token", async () => {
+    const { port, sessions } = listenWithAuth("test-token");
+
+    const controller = new AbortController();
+    try {
+      const res = await fetch(`http://localhost:${port}/sse`, {
+        signal: controller.signal,
+        headers: { Authorization: "Bearer test-token" },
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/event-stream");
+      expect(sessions.size).toBe(1);
+    } finally {
+      controller.abort();
+    }
+  });
+
+  it("POST /messages allows with valid token", async () => {
+    const { port } = listenWithAuth("test-token");
+
+    const res = await fetch(
+      `http://localhost:${port}/messages?sessionId=nonexistent`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-token",
+        },
+        body: JSON.stringify({}),
+      },
+    );
+    // 404 = auth passed, session not found (expected)
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/presentation/transport.ts
+++ b/src/presentation/transport.ts
@@ -4,6 +4,7 @@ import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import express from "express";
 import cors from "cors";
 import type { Server as HttpServer } from "node:http";
+import { createBearerAuthMiddleware } from "./auth-middleware.js";
 
 export type TransportType = "stdio" | "sse";
 
@@ -16,6 +17,10 @@ export function parseTransportType(value?: string): TransportType {
   throw new Error(
     `Invalid MCP_TRANSPORT_TYPE: "${value}". Must be "stdio" or "sse".`,
   );
+}
+
+export interface SseAppOptions {
+  authToken?: string | undefined;
 }
 
 export interface SseApp {
@@ -31,11 +36,21 @@ export interface SseApp {
  *
  * Each GET /sse connection gets its own McpServer instance (via serverFactory)
  * so workflow state is isolated per client.
+ *
+ * When `authToken` is provided, all endpoints require `Authorization: Bearer <token>`.
  */
-export function createSseApp(serverFactory: () => McpServer): SseApp {
+export function createSseApp(
+  serverFactory: () => McpServer,
+  options?: SseAppOptions,
+): SseApp {
   const app = express();
   app.use(cors());
   app.use(express.json());
+
+  const authMiddleware = createBearerAuthMiddleware(options?.authToken);
+  if (authMiddleware) {
+    app.use(authMiddleware);
+  }
 
   const sessions = new Map<string, SSEServerTransport>();
 
@@ -90,7 +105,7 @@ export interface TransportHandle {
 export async function startTransport(
   type: TransportType,
   serverFactory: () => McpServer,
-  options?: { port?: number | undefined },
+  options?: { port?: number | undefined; authToken?: string | undefined },
 ): Promise<TransportHandle> {
   if (type === "stdio") {
     const server = serverFactory();
@@ -103,8 +118,9 @@ export async function startTransport(
     };
   }
 
-  // SSE transport
-  const { app, sessions } = createSseApp(serverFactory);
+  const { app, sessions } = createSseApp(serverFactory, {
+    authToken: options?.authToken,
+  });
   const port = options?.port ?? 3000;
 
   const httpServer: HttpServer = await new Promise((resolve) => {


### PR DESCRIPTION
Add MCP_AUTH_TOKEN environment variable that enables Bearer token
authentication on all SSE endpoints (/sse and /messages).
When set, requests must include `Authorization: Bearer <token>` header.
When unset, behavior is unchanged (no auth, zero overhead).
- Constant-time token comparison (timing-safe)
- Express middleware pattern, applied before route handlers
- 12 new tests (8 unit + 4 integration)
This triggers a minor version bump via semantic-release (feat: → x.Y.z).