### PR TITLE
fix(security): close P0/P1 audit findings — symlink containment, abs …

### DIFF
--- a/src/domain/errors/domain-errors.test.ts
+++ b/src/domain/errors/domain-errors.test.ts
@@ -12,6 +12,9 @@ import {
   EmbeddingError,
   VectorDbError,
   StateTransitionError,
+  AbsolutePathError,
+  SymlinkEscapeError,
+  InvalidArgumentError,
 } from "./index.js";
 
 describe("DomainError (base class)", () => {
@@ -139,6 +142,36 @@ describe("StateTransitionError", () => {
     expect(err.code).toBe("INVALID_STATE_TRANSITION");
     expect(err.message).toContain("idle");
     expect(err.message).toContain("reviewing");
+    expect(err).toBeInstanceOf(DomainError);
+  });
+});
+
+describe("AbsolutePathError", () => {
+  it("has code ABSOLUTE_PATH_REJECTED and includes the path", () => {
+    const err = new AbsolutePathError("/etc/passwd");
+    expect(err.code).toBe("ABSOLUTE_PATH_REJECTED");
+    expect(err.message).toContain("/etc/passwd");
+    expect(err.name).toBe("AbsolutePathError");
+    expect(err).toBeInstanceOf(DomainError);
+  });
+});
+
+describe("SymlinkEscapeError", () => {
+  it("has code SYMLINK_ESCAPE_DETECTED and includes the resolved path", () => {
+    const err = new SymlinkEscapeError("/outside/vault/secret.md");
+    expect(err.code).toBe("SYMLINK_ESCAPE_DETECTED");
+    expect(err.message).toContain("/outside/vault/secret.md");
+    expect(err.name).toBe("SymlinkEscapeError");
+    expect(err).toBeInstanceOf(DomainError);
+  });
+});
+
+describe("InvalidArgumentError", () => {
+  it("has code INVALID_ARGUMENT and includes the argument name", () => {
+    const err = new InvalidArgumentError("path");
+    expect(err.code).toBe("INVALID_ARGUMENT");
+    expect(err.message).toContain("path");
+    expect(err.name).toBe("InvalidArgumentError");
     expect(err).toBeInstanceOf(DomainError);
   });
 });

--- a/src/domain/errors/index.ts
+++ b/src/domain/errors/index.ts
@@ -145,3 +145,31 @@ export class StateTransitionError extends DomainError {
     this.name = "StateTransitionError";
   }
 }
+
+// ── Security errors ───────────────────────────────────────────────
+
+export class AbsolutePathError extends DomainError {
+  constructor(path: string) {
+    super("ABSOLUTE_PATH_REJECTED", `Absolute path rejected: ${path}`);
+    this.name = "AbsolutePathError";
+  }
+}
+
+export class SymlinkEscapeError extends DomainError {
+  constructor(resolvedPath: string) {
+    super(
+      "SYMLINK_ESCAPE_DETECTED",
+      `Symlink escapes vault boundary: ${resolvedPath}`,
+    );
+    this.name = "SymlinkEscapeError";
+  }
+}
+
+// ── Argument errors ───────────────────────────────────────────────
+
+export class InvalidArgumentError extends DomainError {
+  constructor(argumentName: string) {
+    super("INVALID_ARGUMENT", `Required argument missing: ${argumentName}`);
+    this.name = "InvalidArgumentError";
+  }
+}

--- a/src/domain/interfaces/file-watcher.ts
+++ b/src/domain/interfaces/file-watcher.ts
@@ -1,0 +1,12 @@
+export type WatchEventType = "add" | "change" | "unlink";
+
+export interface WatchOptions {
+  ignored?: string[];
+  persistent?: boolean;
+}
+
+export interface IFileWatcher {
+  watch(vaultPath: string, options?: WatchOptions): void;
+  on(event: WatchEventType, handler: (path: string) => void): void;
+  close(): Promise<void>;
+}

--- a/src/domain/interfaces/index.ts
+++ b/src/domain/interfaces/index.ts
@@ -15,3 +15,8 @@ export type {
   FolderSummary,
 } from "./vault-overview-service.js";
 export type { IBacklinkIndex, BacklinkEntry } from "./backlink-index.js";
+export type {
+  IFileWatcher,
+  WatchEventType,
+  WatchOptions,
+} from "./file-watcher.js";

--- a/src/domain/value-objects/safe-path.test.ts
+++ b/src/domain/value-objects/safe-path.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { SafePath } from "./safe-path.js";
-import { PathTraversalError, InvalidNotePathError } from "../errors/index.js";
+import { PathTraversalError, InvalidNotePathError, AbsolutePathError } from "../errors/index.js";
 
 const VAULT_ROOT = "/vault";
 
@@ -44,9 +44,10 @@ describe("SafePath", () => {
       expect(sp.absolute).toBe("/vault/note.md");
     });
 
-    it("strips leading slashes from relative path", () => {
-      const sp = SafePath.create(VAULT_ROOT, "/daily/note.md");
-      expect(sp.relative).toBe("daily/note.md");
+    it("rejects paths with leading slash (absolute path rejection)", () => {
+      expect(() => SafePath.create(VAULT_ROOT, "/daily/note.md")).toThrow(
+        AbsolutePathError,
+      );
     });
 
     it("resolves a directory path (for listNotes)", () => {
@@ -99,11 +100,10 @@ describe("SafePath", () => {
       ).toThrow(PathTraversalError);
     });
 
-    it("treats absolute-looking paths as vault-relative (leading / stripped)", () => {
-      // /etc/passwd → vault-relative "etc/passwd.md" — safely inside vault
-      const sp = SafePath.create(VAULT_ROOT, "/etc/passwd");
-      expect(sp.relative).toBe("etc/passwd.md");
-      expect(sp.absolute).toBe("/vault/etc/passwd.md");
+    it("rejects absolute-looking paths (leading / is not stripped silently)", () => {
+      expect(() => SafePath.create(VAULT_ROOT, "/etc/passwd")).toThrow(
+        AbsolutePathError,
+      );
     });
   });
 
@@ -124,6 +124,50 @@ describe("SafePath", () => {
       expect(() => SafePath.create(VAULT_ROOT, "   ")).toThrow(
         InvalidNotePathError,
       );
+    });
+  });
+
+  describe("absolute path rejection", () => {
+    it("rejects POSIX absolute path /etc/passwd", () => {
+      expect(() => SafePath.create(VAULT_ROOT, "/etc/passwd")).toThrow(AbsolutePathError);
+    });
+
+    it("rejects root path /", () => {
+      expect(() => SafePath.create(VAULT_ROOT, "/")).toThrow(AbsolutePathError);
+    });
+
+    it("rejects triple-slash ///foo", () => {
+      expect(() => SafePath.create(VAULT_ROOT, "///foo")).toThrow(AbsolutePathError);
+    });
+
+    it("rejects Windows drive letter C:\\Windows\\system32", () => {
+      expect(() => SafePath.create(VAULT_ROOT, "C:\\Windows\\system32")).toThrow(AbsolutePathError);
+    });
+
+    it("rejects Windows drive letter C:/Users/file.md", () => {
+      expect(() => SafePath.create(VAULT_ROOT, "C:/Users/file.md")).toThrow(AbsolutePathError);
+    });
+
+    it("rejects UNC path \\\\server\\share\\file.md", () => {
+      expect(() => SafePath.create(VAULT_ROOT, "\\\\server\\share\\file.md")).toThrow(AbsolutePathError);
+    });
+
+    it("rejects UNC path //server/share", () => {
+      expect(() => SafePath.create(VAULT_ROOT, "//server/share")).toThrow(AbsolutePathError);
+    });
+
+    it("rejects URL-encoded absolute %2Fetc%2Fpasswd", () => {
+      expect(() => SafePath.create(VAULT_ROOT, "%2Fetc%2Fpasswd")).toThrow(AbsolutePathError);
+    });
+
+    it("still accepts valid relative paths (no regression)", () => {
+      const sp = SafePath.create(VAULT_ROOT, "notes/valid.md");
+      expect(sp.relative).toBe("notes/valid.md");
+    });
+
+    it("still accepts nested relative paths (no regression)", () => {
+      const sp = SafePath.create(VAULT_ROOT, "sub/dir/file.md");
+      expect(sp.relative).toBe("sub/dir/file.md");
     });
   });
 });

--- a/src/domain/value-objects/safe-path.ts
+++ b/src/domain/value-objects/safe-path.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import {
   PathTraversalError,
   InvalidNotePathError,
+  AbsolutePathError,
 } from "../errors/index.js";
 
 /**
@@ -98,6 +99,11 @@ function sanitize(input: string): string {
   // Normalize backslashes to forward slashes
   decoded = decoded.replace(/\\/g, "/");
 
+  // Reject absolute paths BEFORE stripping — must be explicit rejection, not silent normalization
+  if (isAbsolutePath(decoded)) {
+    throw new AbsolutePathError(input);
+  }
+
   // Check for traversal patterns BEFORE path.resolve can hide them
   if (containsTraversal(decoded)) {
     throw new PathTraversalError(input);
@@ -107,6 +113,16 @@ function sanitize(input: string): string {
   const stripped = decoded.replace(/^\/+/, "");
 
   return stripped;
+}
+
+function isAbsolutePath(p: string): boolean {
+  // POSIX absolute: starts with /
+  if (p.startsWith("/")) return true;
+  // Windows drive letter: C:/ or C:\
+  if (/^[A-Za-z]:[/\\]/.test(p)) return true;
+  // UNC paths: \\server\share or //server/share
+  if (p.startsWith("\\\\") || p.startsWith("//")) return true;
+  return false;
 }
 
 function containsTraversal(p: string): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { LocalFileSystemAdapter } from "./infrastructure/local-fs-adapter.js";
+import { ChokidarFileWatcher } from "./infrastructure/chokidar-file-watcher.js";
 import { createVectorStore } from "./infrastructure/vector-store-factory.js";
 import { OllamaEmbeddingProvider } from "./infrastructure/ollama-embedding.js";
 import { TransformersEmbeddingProvider } from "./infrastructure/transformers-embedding.js";
@@ -72,6 +73,8 @@ async function main(): Promise<void> {
   );
   const port = parseInt(process.env["PORT"] ?? "3000", 10);
   const authToken = process.env["MCP_AUTH_TOKEN"];
+  const hostBindAddress = process.env["HOST_BIND_ADDRESS"] ?? "127.0.0.1";
+  const bodyLimit = process.env["BODY_LIMIT_BYTES"] ?? "1mb";
   const ollamaUrl = process.env["OLLAMA_URL"];
   const ollamaModel = process.env["OLLAMA_MODEL"] ?? "nomic-embed-text";
   const qdrantUrl = process.env["VECTOR_STORE_URL"];
@@ -108,7 +111,14 @@ async function main(): Promise<void> {
   const backlinkIndex = new BacklinkIndexService(new MarkdownPipeline());
 
   // Start background indexing (shared across all connections)
-  const indexer = new VaultIndexer(vaultRoot, vectorStore, embedder);
+  const fileWatcher = new ChokidarFileWatcher();
+  const indexer = new VaultIndexer(
+    vaultRoot,
+    vectorStore,
+    embedder,
+    fileWatcher,
+    fsAdapter,
+  );
 
   // Wire watcher callbacks to backlink index
   indexer.setOnFileIndexed((relPath, content) => {
@@ -163,6 +173,8 @@ async function main(): Promise<void> {
   const handle = await startTransport(transportType, serverFactory, {
     port,
     authToken,
+    hostBindAddress,
+    bodyLimit,
   });
 
   // Handle shutdown

--- a/src/infrastructure/chokidar-file-watcher.test.ts
+++ b/src/infrastructure/chokidar-file-watcher.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const { mockWatch, mockOn, mockClose } = vi.hoisted(() => {
+  return {
+    mockWatch: vi.fn(),
+    mockOn: vi.fn(),
+    mockClose: vi.fn(),
+  };
+});
+
+vi.mock("chokidar", () => ({
+  default: {
+    watch: mockWatch,
+  },
+}));
+
+import { ChokidarFileWatcher } from "./chokidar-file-watcher.js";
+
+describe("ChokidarFileWatcher", () => {
+  beforeEach(() => {
+    mockWatch.mockReset();
+    mockOn.mockReset();
+    mockClose.mockReset();
+    mockClose.mockResolvedValue(undefined);
+    mockWatch.mockReturnValue({
+      on: mockOn,
+      close: mockClose,
+    });
+  });
+
+  it("starts chokidar with markdown-specific defaults", () => {
+    const watcher = new ChokidarFileWatcher();
+
+    watcher.watch("/vault", { persistent: true });
+
+    expect(mockWatch).toHaveBeenCalledOnce();
+    expect(mockWatch).toHaveBeenCalledWith(
+      "/vault",
+      expect.objectContaining({
+        persistent: true,
+        ignoreInitial: true,
+        awaitWriteFinish: { stabilityThreshold: 100 },
+        ignored: expect.any(Function),
+      }),
+    );
+
+    const args = mockWatch.mock.calls[0];
+    const options = args?.[1] as { ignored: (filePath: string) => boolean };
+    expect(options.ignored("/vault/folder")).toBe(false);
+    expect(options.ignored("/vault/note.md")).toBe(false);
+    expect(options.ignored("/vault/note.txt")).toBe(true);
+  });
+
+  it("forwards event handlers to the active chokidar watcher", () => {
+    const watcher = new ChokidarFileWatcher();
+    const handler = vi.fn();
+
+    watcher.watch("/vault");
+    watcher.on("change", handler);
+
+    expect(mockOn).toHaveBeenCalledWith("change", handler);
+  });
+
+  it("closes the active chokidar watcher", async () => {
+    const watcher = new ChokidarFileWatcher();
+
+    watcher.watch("/vault");
+    await watcher.close();
+
+    expect(mockClose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/infrastructure/chokidar-file-watcher.ts
+++ b/src/infrastructure/chokidar-file-watcher.ts
@@ -1,0 +1,38 @@
+import chokidar, { type FSWatcher } from "chokidar";
+import path from "node:path";
+import type {
+  IFileWatcher,
+  WatchEventType,
+  WatchOptions,
+} from "../domain/interfaces/index.js";
+
+export class ChokidarFileWatcher implements IFileWatcher {
+  private watcher: FSWatcher | null = null;
+
+  watch(vaultPath: string, options?: WatchOptions): void {
+    this.watcher = chokidar.watch(vaultPath, {
+      ignored: (filePath: string) => {
+        const ext = path.extname(filePath);
+        if (ext === "" || ext === ".md") {
+          return false;
+        }
+
+        return options?.ignored?.includes(filePath) ?? true;
+      },
+      persistent: options?.persistent ?? true,
+      ignoreInitial: true,
+      awaitWriteFinish: { stabilityThreshold: 100 },
+    });
+  }
+
+  on(event: WatchEventType, handler: (path: string) => void): void {
+    this.watcher?.on(event, handler);
+  }
+
+  async close(): Promise<void> {
+    if (this.watcher) {
+      await this.watcher.close();
+      this.watcher = null;
+    }
+  }
+}

--- a/src/infrastructure/local-fs-adapter.test.ts
+++ b/src/infrastructure/local-fs-adapter.test.ts
@@ -8,6 +8,7 @@ import {
   NoteAlreadyExistsError,
   PathTraversalError,
   VaultNotFoundError,
+  SymlinkEscapeError,
 } from "../domain/errors/index.js";
 
 let vaultDir: string;
@@ -197,5 +198,76 @@ describe("listNotes", () => {
     await expect(adapter.listNotes("../..")).rejects.toThrow(
       PathTraversalError,
     );
+  });
+});
+
+describe("LocalFileSystemAdapter — symlink containment", () => {
+  let vaultDir: string;
+  let outsideDir: string;
+  let adapter: LocalFileSystemAdapter;
+
+  beforeEach(async () => {
+    vaultDir = await fs.mkdtemp(path.join(os.tmpdir(), "vault-symlink-"));
+    outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "outside-"));
+    adapter = await LocalFileSystemAdapter.create(vaultDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(vaultDir, { recursive: true, force: true });
+    await fs.rm(outsideDir, { recursive: true, force: true });
+  });
+
+  it("rejects read through symlink escaping vault", async () => {
+    const outsideFile = path.join(outsideDir, "secret.md");
+    await fs.writeFile(outsideFile, "secret content");
+    await fs.symlink(outsideFile, path.join(vaultDir, "escape.md"));
+
+    await expect(adapter.readNote("escape")).rejects.toThrow(SymlinkEscapeError);
+  });
+
+  it("rejects write to symlink target outside vault", async () => {
+    const outsideFile = path.join(outsideDir, "target.md");
+    await fs.writeFile(outsideFile, "original");
+    await fs.symlink(outsideFile, path.join(vaultDir, "escape.md"));
+
+    await expect(adapter.writeNote("escape", "new content", true)).rejects.toThrow(SymlinkEscapeError);
+  });
+
+  it("rejects delete of symlink pointing outside vault", async () => {
+    const outsideFile = path.join(outsideDir, "target.md");
+    await fs.writeFile(outsideFile, "content");
+    await fs.symlink(outsideFile, path.join(vaultDir, "escape.md"));
+
+    await expect(adapter.deleteNote("escape")).rejects.toThrow(SymlinkEscapeError);
+  });
+
+  it("allows read through symlink pointing inside vault", async () => {
+    await fs.writeFile(path.join(vaultDir, "real.md"), "# Real\n\nContent.\n");
+    await fs.symlink(path.join(vaultDir, "real.md"), path.join(vaultDir, "link.md"));
+
+    const content = await adapter.readNote("link");
+    expect(content).toContain("Real");
+  });
+
+  it("rejects write under symlinked directory pointing outside vault", async () => {
+    await fs.symlink(outsideDir, path.join(vaultDir, "linked-dir"));
+
+    await expect(adapter.writeNote("linked-dir/new-file", "content")).rejects.toThrow(SymlinkEscapeError);
+  });
+
+  it("handles vault root that is itself a symlink", async () => {
+    const realVault = await fs.mkdtemp(path.join(os.tmpdir(), "real-vault-"));
+    const symlinkVault = path.join(os.tmpdir(), `symlink-vault-${Date.now()}`);
+    await fs.symlink(realVault, symlinkVault);
+
+    try {
+      const symlinkAdapter = await LocalFileSystemAdapter.create(symlinkVault);
+      await fs.writeFile(path.join(realVault, "note.md"), "# Note\n\nContent.\n");
+      const content = await symlinkAdapter.readNote("note");
+      expect(content).toContain("Note");
+    } finally {
+      await fs.unlink(symlinkVault);
+      await fs.rm(realVault, { recursive: true, force: true });
+    }
   });
 });

--- a/src/infrastructure/local-fs-adapter.ts
+++ b/src/infrastructure/local-fs-adapter.ts
@@ -9,20 +9,19 @@ import {
   VaultNotFoundError,
   NoteNotFoundError,
   NoteAlreadyExistsError,
+  SymlinkEscapeError,
 } from "../domain/errors/index.js";
 import { SafePath } from "../domain/value-objects/index.js";
 
 export class LocalFileSystemAdapter implements IFileSystemAdapter {
   private readonly vaultRoot: string;
+  private readonly canonicalRoot: string;
 
-  private constructor(vaultRoot: string) {
+  private constructor(vaultRoot: string, canonicalRoot: string) {
     this.vaultRoot = vaultRoot;
+    this.canonicalRoot = canonicalRoot;
   }
 
-  /**
-   * Factory that validates the vault directory exists.
-   * @throws VaultNotFoundError if path doesn't exist or is not a directory.
-   */
   static async create(vaultRoot: string): Promise<LocalFileSystemAdapter> {
     const resolved = path.resolve(vaultRoot);
     try {
@@ -34,13 +33,47 @@ export class LocalFileSystemAdapter implements IFileSystemAdapter {
       if (err instanceof VaultNotFoundError) throw err;
       throw new VaultNotFoundError(vaultRoot);
     }
-    return new LocalFileSystemAdapter(resolved);
+    const canonicalRoot = await fs.realpath(resolved);
+    return new LocalFileSystemAdapter(resolved, canonicalRoot);
+  }
+
+  private async assertContained(absPath: string): Promise<void> {
+    let canonical: string;
+    try {
+      canonical = await fs.realpath(absPath);
+    } catch {
+      await this.assertParentContained(absPath);
+      return;
+    }
+    if (!canonical.startsWith(this.canonicalRoot + path.sep) && canonical !== this.canonicalRoot) {
+      throw new SymlinkEscapeError(canonical);
+    }
+  }
+
+  private async assertParentContained(absPath: string): Promise<void> {
+    let current = path.dirname(absPath);
+    while (true) {
+      try {
+        const canonical = await fs.realpath(current);
+        if (!canonical.startsWith(this.canonicalRoot + path.sep) && canonical !== this.canonicalRoot) {
+          throw new SymlinkEscapeError(canonical);
+        }
+        return;
+      } catch (err) {
+        if (err instanceof SymlinkEscapeError) throw err;
+        const parent = path.dirname(current);
+        if (parent === current) return;
+        current = parent;
+      }
+    }
   }
 
   async listNotes(directory?: string): Promise<string[]> {
     const target = directory
       ? SafePath.createDirectory(this.vaultRoot, directory)
       : SafePath.createDirectory(this.vaultRoot, "");
+
+    await this.assertContained(target.absolute);
 
     try {
       await fs.access(target.absolute);
@@ -73,6 +106,7 @@ export class LocalFileSystemAdapter implements IFileSystemAdapter {
 
   async readNote(notePath: string): Promise<string> {
     const safePath = SafePath.create(this.vaultRoot, notePath);
+    await this.assertContained(safePath.absolute);
     try {
       return await fs.readFile(safePath.absolute, "utf-8");
     } catch {
@@ -86,6 +120,7 @@ export class LocalFileSystemAdapter implements IFileSystemAdapter {
     overwrite?: boolean,
   ): Promise<void> {
     const safePath = SafePath.create(this.vaultRoot, notePath);
+    await this.assertContained(safePath.absolute);
 
     // Check for existing file when overwrite is not enabled
     if (!overwrite) {
@@ -122,6 +157,7 @@ export class LocalFileSystemAdapter implements IFileSystemAdapter {
 
   async deleteNote(notePath: string): Promise<void> {
     const safePath = SafePath.create(this.vaultRoot, notePath);
+    await this.assertContained(safePath.absolute);
     try {
       await fs.unlink(safePath.absolute);
     } catch {
@@ -131,6 +167,7 @@ export class LocalFileSystemAdapter implements IFileSystemAdapter {
 
   async exists(notePath: string): Promise<boolean> {
     const safePath = SafePath.create(this.vaultRoot, notePath);
+    await this.assertContained(safePath.absolute);
     try {
       await fs.access(safePath.absolute);
       return true;
@@ -141,6 +178,7 @@ export class LocalFileSystemAdapter implements IFileSystemAdapter {
 
   async stat(notePath: string): Promise<NoteStat> {
     const safePath = SafePath.create(this.vaultRoot, notePath);
+    await this.assertContained(safePath.absolute);
     try {
       const fileStat = await fs.stat(safePath.absolute);
       return {

--- a/src/presentation/mcp-tools.test.ts
+++ b/src/presentation/mcp-tools.test.ts
@@ -6,7 +6,8 @@ import { createMcpServer, type McpDependencies } from "./mcp-tools.js";
 import { LocalFileSystemAdapter } from "../infrastructure/local-fs-adapter.js";
 import { InMemoryVectorStore } from "../infrastructure/vector-store/in-memory-vector-store.js";
 import { WorkflowStateMachine } from "../use-cases/workflow-state.js";
-import type { IEmbeddingProvider } from "../domain/interfaces/index.js";
+import { VaultIndexer } from "../use-cases/vault-indexer.js";
+import type { IEmbeddingProvider, IFileWatcher, WatchEventType } from "../domain/interfaces/index.js";
 import { MarkdownPipeline } from "../use-cases/markdown-pipeline.js";
 import { BacklinkIndexService } from "../use-cases/backlink-index.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -23,6 +24,12 @@ class FakeEmbedder implements IEmbeddingProvider {
   async embedBatch(texts: string[]): Promise<number[][]> {
     return Promise.all(texts.map((t) => this.embed(t)));
   }
+}
+
+class StubFileWatcher implements IFileWatcher {
+  watch(): void {}
+  on(_event: WatchEventType, _handler: (_path: string) => void): void {}
+  async close(): Promise<void> {}
 }
 
 // ── Test setup ────────────────────────────────────────────────────
@@ -527,10 +534,10 @@ describe("system tool", () => {
     });
     const content = result.content as Array<{ type: string; text: string }>;
     const parsed = JSON.parse(content[0]!.text);
-    expect(parsed.result.vaultRoot).toBe(tmpDir);
     expect(typeof parsed.result.indexedDocuments).toBe("number");
     expect(typeof parsed.result.backlinkIndexSize).toBe("number");
     expect(parsed.result.backlinkIndexSize).toBeGreaterThan(0);
+    expect(parsed.result.vaultRoot).toBeUndefined();
   });
 
   it("returns vault overview with folder structure", async () => {
@@ -553,5 +560,99 @@ describe("system tool", () => {
     const daily = root.children.find((f: { path: string }) => f.path === "daily");
     expect(daily).toBeDefined();
     expect(daily.fileCount).toBe(1);
+  });
+});
+
+describe("system tool — indexer health fields", () => {
+  let indexerTmpDir: string;
+  let indexerClient: Client;
+  let indexerCleanup: () => Promise<void>;
+
+  beforeEach(async () => {
+    indexerTmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "mcp-indexer-test-"));
+    await fs.writeFile(
+      path.join(indexerTmpDir, "note.md"),
+      "# Note\n\nContent.\n",
+    );
+
+    const fsAdapter = await LocalFileSystemAdapter.create(indexerTmpDir);
+    const vectorStore = new InMemoryVectorStore();
+    const embedder = new FakeEmbedder();
+    const workflow = new WorkflowStateMachine();
+    const indexer = new VaultIndexer(
+      indexerTmpDir,
+      vectorStore,
+      embedder,
+      new StubFileWatcher(),
+      fsAdapter,
+    );
+
+    const indexerDeps: McpDependencies = {
+      fsAdapter,
+      vectorStore,
+      embedder,
+      workflow,
+      vaultRoot: indexerTmpDir,
+      indexer,
+    };
+
+    const server = createMcpServer(indexerDeps);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    indexerClient = new Client({ name: "test-indexer-client", version: "1.0.0" });
+    await server.connect(serverTransport);
+    await indexerClient.connect(clientTransport);
+
+    indexerCleanup = async () => {
+      await indexerClient.close();
+      await server.close();
+    };
+  });
+
+  afterEach(async () => {
+    await indexerCleanup();
+    await fs.rm(indexerTmpDir, { recursive: true, force: true });
+  });
+
+  it("includes indexing health fields in status response", async () => {
+    const result = await indexerClient.callTool({
+      name: "system",
+      arguments: { action: "status" },
+    });
+    const content = result.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0]!.text);
+
+    expect(parsed.result.indexingState).toBeDefined();
+    expect(["idle", "indexing", "watching", "error"]).toContain(parsed.result.indexingState);
+    expect(parsed.result.watcherState).toBeDefined();
+    expect(["stopped", "active"]).toContain(parsed.result.watcherState);
+    expect(typeof parsed.result.queueDepth).toBe("number");
+    expect(typeof parsed.result.failureCount).toBe("number");
+    expect(typeof parsed.result.indexedDocuments).toBe("number");
+  });
+
+  it("returns idle indexingState when watcher is not started", async () => {
+    const result = await indexerClient.callTool({
+      name: "system",
+      arguments: { action: "status" },
+    });
+    const content = result.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0]!.text);
+
+    expect(parsed.result.indexingState).toBe("idle");
+    expect(parsed.result.watcherState).toBe("stopped");
+    expect(parsed.result.failureCount).toBe(0);
+    expect(parsed.result.lastFailure).toBeNull();
+  });
+
+  it("does not expose vault root absolute path", async () => {
+    const result = await indexerClient.callTool({
+      name: "system",
+      arguments: { action: "status" },
+    });
+    const content = result.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0]!.text);
+
+    expect(parsed.result.vaultRoot).toBeUndefined();
+    expect(JSON.stringify(parsed.result)).not.toContain(indexerTmpDir);
   });
 });

--- a/src/presentation/mcp-tools.ts
+++ b/src/presentation/mcp-tools.ts
@@ -25,7 +25,7 @@ import { VaultIndexer } from "../use-cases/vault-indexer.js";
 import { MarkdownFileRepository } from "../infrastructure/markdown-file-repository.js";
 import { RegexTemplateEngine } from "../infrastructure/regex-template-engine.js";
 import { UnifiedDiffService } from "../infrastructure/diff-service.js";
-import { DomainError } from "../domain/errors/index.js";
+import { DomainError, InvalidArgumentError } from "../domain/errors/index.js";
 
 export interface McpDependencies {
   fsAdapter: IFileSystemAdapter;
@@ -71,21 +71,21 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           return notes;
         }
         case "read": {
-          if (!path) throw new Error("path is required for read");
+          if (!path) throw new InvalidArgumentError("path");
           const noteContent = await deps.fsAdapter.readNote(path);
           return noteContent;
         }
         case "create": {
-          if (!path) throw new Error("path is required for create");
-          if (!content) throw new Error("content is required for create");
+          if (!path) throw new InvalidArgumentError("path");
+          if (!content) throw new InvalidArgumentError("content");
           await deps.fsAdapter.writeNote(path, content);
           deps.backlinkIndex?.updateFile(path, content);
           deps.indexer?.indexFile(path).catch(() => {/* background */});
           return `Note created: ${path}`;
         }
         case "update": {
-          if (!path) throw new Error("path is required for update");
-          if (!content) throw new Error("content is required for update");
+          if (!path) throw new InvalidArgumentError("path");
+          if (!content) throw new InvalidArgumentError("content");
           const useCase = new UpdateFileUseCase(deps.fsAdapter);
           const result = await useCase.execute({ path, content });
           deps.backlinkIndex?.updateFile(path, content);
@@ -93,20 +93,20 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           return result.message;
         }
         case "delete": {
-          if (!path) throw new Error("path is required for delete");
+          if (!path) throw new InvalidArgumentError("path");
           await deps.fsAdapter.deleteNote(path);
           deps.backlinkIndex?.removeFile(path);
           deps.indexer?.removeFile(path).catch(() => {/* background */});
           return `Note deleted: ${path}`;
         }
         case "stat": {
-          if (!path) throw new Error("path is required for stat");
+          if (!path) throw new InvalidArgumentError("path");
           const stat = await deps.fsAdapter.stat(path);
           return stat;
         }
         case "create_from_template": {
-          if (!path) throw new Error("path is required for create_from_template");
-          if (!templatePath) throw new Error("templatePath is required for create_from_template");
+          if (!path) throw new InvalidArgumentError("path");
+          if (!templatePath) throw new InvalidArgumentError("templatePath");
           const engine = new RegexTemplateEngine();
           const useCase = new CreateFromTemplateUseCase(deps.fsAdapter, engine);
           const result = await useCase.execute({
@@ -121,7 +121,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           return result.message;
         }
         default:
-          throw new Error(`Unknown vault action: ${String(action)}`);
+          throw new InvalidArgumentError("action");
       }
     });
   });
@@ -190,9 +190,9 @@ export function createMcpServer(deps: McpDependencies): McpServer {
       }
 
       // ── Single mode — validate required fields ─────────────
-      if (!notePath) throw new Error("path is required for single edit");
-      if (!operation) throw new Error("operation is required for single edit");
-      if (content === undefined) throw new Error("content is required for single edit");
+      if (!notePath) throw new InvalidArgumentError("path");
+      if (!operation) throw new InvalidArgumentError("operation");
+      if (content === undefined) throw new InvalidArgumentError("content");
 
       const source = await deps.fsAdapter.readNote(notePath);
       const diffService = new UnifiedDiffService();
@@ -209,7 +209,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
       // ── Freeform operations ─────────────────────────────────────
       if (operation === "line_replace") {
         if (startLine === undefined || endLine === undefined) {
-          throw new Error("startLine and endLine are required for line_replace");
+          throw new InvalidArgumentError("startLine/endLine");
         }
         const newContent = FreeformEditor.lineReplace(source, startLine, endLine, content);
         const result = await dryRunEditor.execute({
@@ -224,7 +224,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
 
       if (operation === "string_replace") {
         if (!searchText) {
-          throw new Error("searchText is required for string_replace");
+          throw new InvalidArgumentError("searchText");
         }
         const newContent = FreeformEditor.stringReplace(source, searchText, content, replaceAll ?? false);
         const result = await dryRunEditor.execute({
@@ -318,8 +318,8 @@ export function createMcpServer(deps: McpDependencies): McpServer {
     return wrapTool(deps.workflow, "view", async () => {
       switch (action) {
         case "search": {
-          if (!notePath) throw new Error("path is required for search");
-          if (!query) throw new Error("query is required for search");
+          if (!notePath) throw new InvalidArgumentError("path");
+          if (!query) throw new InvalidArgumentError("query");
           const source = await deps.fsAdapter.readNote(notePath);
           const fragments = retriever.retrieve(source, query, {
             maxChunks: maxChunks ?? 5,
@@ -332,7 +332,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           }));
         }
         case "global_search": {
-          if (!query) throw new Error("query is required for global_search");
+          if (!query) throw new InvalidArgumentError("query");
           const results = await vaultSearcher.search(query, {
             maxResults: maxChunks ?? 20,
             directory,
@@ -346,7 +346,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           }));
         }
         case "semantic_search": {
-          if (!query) throw new Error("query is required for semantic_search");
+          if (!query) throw new InvalidArgumentError("query");
           const results = await hybridSearcher.search(query, {
             k: maxChunks ?? 10,
             directory,
@@ -361,13 +361,13 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           }));
         }
         case "outline": {
-          if (!notePath) throw new Error("path is required for outline");
+          if (!notePath) throw new InvalidArgumentError("path");
           const source = await deps.fsAdapter.readNote(notePath);
           const tree = pipeline.parse(source);
           return AstNavigator.findAllHeadings(tree);
         }
         case "read": {
-          if (!notePath) throw new Error("path is required for read");
+          if (!notePath) throw new InvalidArgumentError("path");
           if (heading) {
             const repo = new MarkdownFileRepository(deps.fsAdapter, pipeline);
             const useCase = new ReadByHeadingUseCase(repo, pipeline);
@@ -382,7 +382,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           return content;
         }
         case "frontmatter_get": {
-          if (!notePath) throw new Error("path is required for frontmatter_get");
+          if (!notePath) throw new InvalidArgumentError("path");
           const repo = new MarkdownFileRepository(deps.fsAdapter, pipeline);
           const useCase = new GetFrontmatterUseCase(repo);
           const result = await useCase.execute({ path: notePath });
@@ -399,7 +399,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           return result;
         }
         case "backlinks": {
-          if (!notePath) throw new Error("path is required for backlinks");
+          if (!notePath) throw new InvalidArgumentError("path");
           if (!deps.backlinkIndex) {
             return { target: notePath, backlinks: [], count: 0 };
           }
@@ -407,7 +407,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           return { target: notePath, backlinks, count: backlinks.length };
         }
         default:
-          throw new Error(`Unknown view action: ${String(action)}`);
+          throw new InvalidArgumentError("action");
       }
     });
   });
@@ -434,7 +434,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           };
         }
         case "transition": {
-          if (!transition) throw new Error("transition name is required");
+          if (!transition) throw new InvalidArgumentError("transition");
           deps.workflow.fire(transition);
           return {
             currentState: deps.workflow.currentPlace,
@@ -449,7 +449,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           return { currentState: deps.workflow.currentPlace };
         }
         default:
-          throw new Error(`Unknown workflow action: ${String(action)}`);
+          throw new InvalidArgumentError("action");
       }
     });
   });
@@ -468,12 +468,21 @@ export function createMcpServer(deps: McpDependencies): McpServer {
     return wrapTool(deps.workflow, "system", async () => {
       switch (action) {
         case "status": {
-          const indexedDocs = await deps.vectorStore.size();
-          return {
-            vaultRoot: deps.vaultRoot,
-            indexedDocuments: indexedDocs,
+          const base = {
+            indexedDocuments: await deps.vectorStore.size(),
             backlinkIndexSize: deps.backlinkIndex?.indexSize ?? 0,
             workflowState: deps.workflow.currentPlace,
+          };
+          if (!deps.indexer) return base;
+          const health = await deps.indexer.getHealthStatus();
+          return {
+            ...base,
+            indexedDocuments: health.indexedDocuments,
+            indexingState: health.indexingState,
+            watcherState: health.watcherState,
+            queueDepth: health.queueDepth,
+            failureCount: health.failureCount,
+            lastFailure: health.lastFailure,
           };
         }
         case "reindex": {
@@ -503,7 +512,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           return overviewService.getOverview(maxDepth);
         }
         default:
-          throw new Error(`Unknown system action: ${String(action)}`);
+          throw new InvalidArgumentError("action");
       }
     });
   });
@@ -528,9 +537,10 @@ async function wrapTool<T>(
     const message =
       err instanceof DomainError
         ? `[${err.code}] ${err.message}`
-        : err instanceof Error
-          ? err.message
-          : String(err);
+        : "Internal error occurred";
+    if (!(err instanceof DomainError)) {
+      console.error("Unexpected tool error:", err);
+    }
     return {
       content: [{ type: "text", text: message }],
       isError: true,

--- a/src/presentation/transport.test.ts
+++ b/src/presentation/transport.test.ts
@@ -135,14 +135,54 @@ describe("createSseApp", () => {
     expect(sessions.size).toBe(0);
   });
 
-  it("includes CORS headers in responses", async () => {
+  it("allows localhost origins in CORS", async () => {
+    const { port } = listen();
+
+    const res = await fetch(`http://localhost:${port}/messages`, {
+      method: "OPTIONS",
+      headers: { Origin: "http://localhost:3000" },
+    });
+    expect(res.headers.get("access-control-allow-origin")).toBe("http://localhost:3000");
+  });
+
+  it("rejects non-localhost origins in CORS", async () => {
     const { port } = listen();
 
     const res = await fetch(`http://localhost:${port}/messages`, {
       method: "OPTIONS",
       headers: { Origin: "http://example.com" },
     });
-    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 413 JSON when body exceeds bodyLimit", async () => {
+    const serverFactory = createMockServerFactory();
+    const { app } = createSseApp(serverFactory, { bodyLimit: "1b" });
+    const httpServer = app.listen(0);
+    openServers.push(httpServer);
+    const { port } = httpServer.address() as AddressInfo;
+
+    const res = await fetch(`http://localhost:${port}/messages?sessionId=x`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ large: "x".repeat(100) }),
+    });
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Payload too large");
+  });
+
+  it("returns 400 JSON for malformed JSON body", async () => {
+    const { port } = listen();
+
+    const res = await fetch(`http://localhost:${port}/messages?sessionId=x`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{ not valid json",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Bad request");
   });
 });
 

--- a/src/presentation/transport.ts
+++ b/src/presentation/transport.ts
@@ -8,9 +8,6 @@ import { createBearerAuthMiddleware } from "./auth-middleware.js";
 
 export type TransportType = "stdio" | "sse";
 
-/**
- * Validate and parse the MCP_TRANSPORT_TYPE environment variable.
- */
 export function parseTransportType(value?: string): TransportType {
   if (value === undefined || value === "stdio") return "stdio";
   if (value === "sse") return "sse";
@@ -21,6 +18,7 @@ export function parseTransportType(value?: string): TransportType {
 
 export interface SseAppOptions {
   authToken?: string | undefined;
+  bodyLimit?: string | undefined;
 }
 
 export interface SseApp {
@@ -28,24 +26,30 @@ export interface SseApp {
   sessions: Map<string, SSEServerTransport>;
 }
 
-/**
- * Create an Express app wired for SSE transport.
- *
- * - GET  /sse       — establishes an SSE stream (one per client)
- * - POST /messages   — forwards JSON-RPC messages to the correct session
- *
- * Each GET /sse connection gets its own McpServer instance (via serverFactory)
- * so workflow state is isolated per client.
- *
- * When `authToken` is provided, all endpoints require `Authorization: Bearer <token>`.
- */
+function isLocalhostOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    return url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
 export function createSseApp(
   serverFactory: () => McpServer,
   options?: SseAppOptions,
 ): SseApp {
   const app = express();
-  app.use(cors());
-  app.use(express.json());
+  app.use(cors({
+    origin: (origin, callback) => {
+      if (!origin || isLocalhostOrigin(origin)) {
+        callback(null, true);
+      } else {
+        callback(new Error("CORS: origin not allowed"));
+      }
+    },
+  }));
+  app.use(express.json({ limit: options?.bodyLimit ?? "1mb" }));
 
   const authMiddleware = createBearerAuthMiddleware(options?.authToken);
   if (authMiddleware) {
@@ -58,8 +62,6 @@ export function createSseApp(
     const transport = new SSEServerTransport("/messages", res);
     const server = serverFactory();
 
-    // Register session before connect (which writes SSE headers)
-    // so it's available by the time the client receives the response.
     sessions.set(transport.sessionId, transport);
 
     res.on("close", () => {
@@ -89,6 +91,19 @@ export function createSseApp(
     await transport.handlePostMessage(req, res, req.body);
   });
 
+  app.use((err: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    const status = (err as { status?: number; statusCode?: number }).status
+      ?? (err as { status?: number; statusCode?: number }).statusCode
+      ?? 500;
+    if (status === 413) {
+      res.status(413).json({ error: "Payload too large" });
+    } else if (status === 400) {
+      res.status(400).json({ error: "Bad request" });
+    } else {
+      res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
   return { app, sessions };
 }
 
@@ -105,7 +120,12 @@ export interface TransportHandle {
 export async function startTransport(
   type: TransportType,
   serverFactory: () => McpServer,
-  options?: { port?: number | undefined; authToken?: string | undefined },
+  options?: {
+    port?: number | undefined;
+    authToken?: string | undefined;
+    hostBindAddress?: string | undefined;
+    bodyLimit?: string | undefined;
+  },
 ): Promise<TransportHandle> {
   if (type === "stdio") {
     const server = serverFactory();
@@ -120,12 +140,14 @@ export async function startTransport(
 
   const { app, sessions } = createSseApp(serverFactory, {
     authToken: options?.authToken,
+    bodyLimit: options?.bodyLimit,
   });
   const port = options?.port ?? 3000;
+  const host = options?.hostBindAddress ?? "127.0.0.1";
 
   const httpServer: HttpServer = await new Promise((resolve) => {
-    const s = app.listen(port, () => {
-      console.error(`SSE transport listening on http://localhost:${port}/sse`);
+    const s = app.listen(port, host, () => {
+      console.error(`SSE transport listening on http://${host}:${port}/sse`);
       resolve(s);
     });
   });

--- a/src/use-cases/vault-indexer.test.ts
+++ b/src/use-cases/vault-indexer.test.ts
@@ -1,15 +1,24 @@
+/// <reference types="node" />
+
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import { VaultIndexer } from "./vault-indexer.js";
+import { LocalFileSystemAdapter } from "../infrastructure/local-fs-adapter.js";
 import { InMemoryVectorStore } from "../infrastructure/vector-store/in-memory-vector-store.js";
-import type { IEmbeddingProvider } from "../domain/interfaces/index.js";
+import type {
+  IEmbeddingProvider,
+  IFileSystemAdapter,
+  IFileWatcher,
+  WatchEventType,
+} from "../domain/interfaces/index.js";
 
 // ── Fake embedding provider ───────────────────────────────────────
 
 class FakeEmbeddingProvider implements IEmbeddingProvider {
   readonly dimensions = 3;
+  readonly modelName = "fake-embedder";
   readonly embedCalls: string[] = [];
 
   /** Returns a deterministic vector based on text hash. */
@@ -45,13 +54,39 @@ function simpleHash(s: string): number {
 let tmpDir: string;
 let store: InMemoryVectorStore;
 let embedder: FakeEmbeddingProvider;
+let fsAdapter: IFileSystemAdapter;
+let watcher: MockFileWatcher;
 let indexer: VaultIndexer;
+
+class MockFileWatcher implements IFileWatcher {
+  watchedPath: string | null = null;
+  closeCalls = 0;
+  readonly handlers: Partial<Record<WatchEventType, (path: string) => void>> = {};
+
+  watch(vaultPath: string): void {
+    this.watchedPath = vaultPath;
+  }
+
+  on(event: WatchEventType, handler: (path: string) => void): void {
+    this.handlers[event] = handler;
+  }
+
+  async close(): Promise<void> {
+    this.closeCalls++;
+  }
+
+  emit(event: WatchEventType, filePath: string): void {
+    this.handlers[event]?.(filePath);
+  }
+}
 
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "indexer-test-"));
   store = new InMemoryVectorStore();
   embedder = new FakeEmbeddingProvider();
-  indexer = new VaultIndexer(tmpDir, store, embedder);
+  fsAdapter = await LocalFileSystemAdapter.create(tmpDir);
+  watcher = new MockFileWatcher();
+  indexer = new VaultIndexer(tmpDir, store, embedder, watcher, fsAdapter);
 });
 
 afterEach(async () => {
@@ -244,23 +279,22 @@ describe("VaultIndexer", () => {
     it("starts and stops without error", async () => {
       await indexer.startWatching({ debounceMs: 50 });
       await indexer.stop();
+
+      expect(watcher.watchedPath).toBe(tmpDir);
+      expect(watcher.closeCalls).toBe(1);
     });
 
-    it("detects new files and queues them for indexing", async () => {
+    it("detects new files and auto-indexes them without manual processQueue", async () => {
       await indexer.startWatching({ debounceMs: 50 });
 
-      // Small delay to let chokidar initialise
-      await sleep(200);
-
-      // Create a file after watcher starts
       await fs.writeFile(
         path.join(tmpDir, "watched.md"),
         "# Watched\n\nContent.\n",
       );
 
-      // Wait for chokidar detection + awaitWriteFinish + debounce
-      await sleep(500);
-      await indexer.processQueue();
+      watcher.emit("add", path.join(tmpDir, "watched.md"));
+
+      await sleep(200);
 
       expect(await store.has("watched.md")).toBe(true);
     });
@@ -268,17 +302,143 @@ describe("VaultIndexer", () => {
     it("ignores non-.md files", async () => {
       await indexer.startWatching({ debounceMs: 50 });
 
-      await sleep(200);
-
       await fs.writeFile(
         path.join(tmpDir, "ignored.txt"),
         "not markdown",
       );
 
-      await sleep(150);
-      await indexer.processQueue();
+      watcher.emit("add", path.join(tmpDir, "ignored.txt"));
+
+      await sleep(100);
 
       expect(await store.size()).toBe(0);
+    });
+
+    it("processes a burst of file events — all eventually indexed", async () => {
+      await indexer.startWatching({ debounceMs: 50 });
+
+      await fs.writeFile(path.join(tmpDir, "burst1.md"), "# B1\n\nContent.\n");
+      await fs.writeFile(path.join(tmpDir, "burst2.md"), "# B2\n\nContent.\n");
+      await fs.writeFile(path.join(tmpDir, "burst3.md"), "# B3\n\nContent.\n");
+
+      watcher.emit("add", path.join(tmpDir, "burst1.md"));
+      watcher.emit("add", path.join(tmpDir, "burst2.md"));
+      watcher.emit("add", path.join(tmpDir, "burst3.md"));
+
+      await sleep(250);
+
+      expect(await store.has("burst1.md")).toBe(true);
+      expect(await store.has("burst2.md")).toBe(true);
+      expect(await store.has("burst3.md")).toBe(true);
+    });
+
+    it("tracks failure count when indexing fails", async () => {
+      const origEmbed = embedder.embed.bind(embedder);
+      embedder.embed = async (text: string) => {
+        if (text.includes("FailMe")) throw new Error("embed error");
+        return origEmbed(text);
+      };
+
+      await indexer.startWatching({ debounceMs: 50 });
+
+      await fs.writeFile(
+        path.join(tmpDir, "fail.md"),
+        "# FailMe\n\nThis will fail.\n",
+      );
+
+      watcher.emit("add", path.join(tmpDir, "fail.md"));
+
+      await sleep(200);
+
+      expect(indexer.failureCount).toBeGreaterThanOrEqual(1);
+      expect(indexer.lastFailureTime).toBeInstanceOf(Date);
+      expect(indexer.lastFailureSource).toBe("fail.md");
+    });
+
+    it("removes a deleted markdown file from the vector store on unlink", async () => {
+      await fs.writeFile(
+        path.join(tmpDir, "gone.md"),
+        "# Present\n\nContent.\n",
+      );
+      await indexer.indexFile("gone.md");
+      expect(await store.has("gone.md")).toBe(true);
+
+      await indexer.startWatching({ debounceMs: 50 });
+
+      await fs.unlink(path.join(tmpDir, "gone.md"));
+
+      watcher.emit("unlink", path.join(tmpDir, "gone.md"));
+
+      await sleep(100);
+
+      expect(await store.has("gone.md")).toBe(false);
+    });
+  });
+  describe("getHealthStatus", () => {
+    it("returns idle state with zero counters when freshly created", async () => {
+      const status = await indexer.getHealthStatus();
+
+      expect(status.indexingState).toBe("idle");
+      expect(status.watcherState).toBe("stopped");
+      expect(status.queueDepth).toBe(0);
+      expect(status.failureCount).toBe(0);
+      expect(status.lastFailure).toBeNull();
+      expect(typeof status.indexedDocuments).toBe("number");
+    });
+
+    it("returns watching state while watcher is active", async () => {
+      await indexer.startWatching({ debounceMs: 50 });
+
+      const status = await indexer.getHealthStatus();
+
+      expect(status.indexingState).toBe("watching");
+      expect(status.watcherState).toBe("active");
+    });
+
+    it("returns error state after an indexing failure", async () => {
+      const origEmbed = embedder.embed.bind(embedder);
+      embedder.embed = async (text: string) => {
+        if (text.includes("FailHealth")) throw new Error("embed error");
+        return origEmbed(text);
+      };
+
+      await indexer.startWatching({ debounceMs: 50 });
+      await fs.writeFile(
+        path.join(tmpDir, "fail-health.md"),
+        "# FailHealth\n\nThis will fail.\n",
+      );
+      watcher.emit("add", path.join(tmpDir, "fail-health.md"));
+      await sleep(200);
+      await indexer.stop();
+
+      const status = await indexer.getHealthStatus();
+
+      expect(status.failureCount).toBeGreaterThanOrEqual(1);
+      expect(status.indexingState).toBe("error");
+      expect(status.lastFailure).not.toBeNull();
+      expect(status.lastFailure!.source).toBe("fail-health.md");
+      expect(status.lastFailure!.time).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    it("indexedDocuments reflects documents in the vector store", async () => {
+      await fs.writeFile(
+        path.join(tmpDir, "health-doc.md"),
+        "# Health\n\nContent.\n",
+      );
+      await indexer.indexFile("health-doc.md");
+
+      const status = await indexer.getHealthStatus();
+
+      expect(status.indexedDocuments).toBe(1);
+    });
+
+    it("queueDepth reflects files waiting to be processed", () => {
+      indexer.enqueue("pending-a.md");
+      indexer.enqueue("pending-b.md");
+
+      void indexer.getHealthStatus().then((status) => {
+        expect(status.queueDepth).toBeGreaterThanOrEqual(0);
+      });
     });
   });
 });

--- a/src/use-cases/vault-indexer.ts
+++ b/src/use-cases/vault-indexer.ts
@@ -1,8 +1,8 @@
-import fs from "node:fs/promises";
 import path from "node:path";
-import chokidar, { type FSWatcher } from "chokidar";
 import type {
   IEmbeddingProvider,
+  IFileSystemAdapter,
+  IFileWatcher,
   IVectorStore,
   VectorChunk,
 } from "../domain/interfaces/index.js";
@@ -12,6 +12,17 @@ import { MarkdownPipeline } from "./markdown-pipeline.js";
 export interface WatcherOptions {
   /** Milliseconds to debounce file-change events. Default: 500. */
   debounceMs?: number;
+}
+
+/** Snapshot of the indexer's current health and operational state. */
+export interface IndexingHealthStatus {
+  /** Derived state priority: 'indexing' > 'watching' > 'error' > 'idle'. */
+  indexingState: "idle" | "indexing" | "watching" | "error";
+  watcherState: "stopped" | "active";
+  queueDepth: number;
+  failureCount: number;
+  lastFailure: { time: string; source: string } | null;
+  indexedDocuments: number;
 }
 
 /**
@@ -27,10 +38,11 @@ export class VaultIndexer {
   private readonly vaultRoot: string;
   private readonly store: IVectorStore;
   private readonly embedder: IEmbeddingProvider;
+  private readonly watcherAdapter: IFileWatcher;
+  private readonly fs: IFileSystemAdapter;
   private readonly chunker: MarkdownChunker;
-  private watcher: FSWatcher | null = null;
+  private watcherActive = false;
 
-  /** Set of vault-relative paths pending indexing. */
   /** Callback invoked after a file is successfully indexed. */
   private onFileIndexedCb?: (relativePath: string, content: string) => void;
   /** Callback invoked after a file is removed from the index. */
@@ -41,14 +53,28 @@ export class VaultIndexer {
   /** Debounce timers keyed by relative path. */
   private readonly debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
+  /** Serialization guard — prevents concurrent processQueue runs. */
+  private isProcessing = false;
+
+  /** Number of indexing failures since startup. */
+  failureCount = 0;
+  /** Timestamp of the most recent indexing failure, or null if none. */
+  lastFailureTime: Date | null = null;
+  /** Vault-relative path of the most recently failed file, or null if none. */
+  lastFailureSource: string | null = null;
+
   constructor(
     vaultRoot: string,
     store: IVectorStore,
     embedder: IEmbeddingProvider,
+    watcher: IFileWatcher,
+    fs: IFileSystemAdapter,
   ) {
     this.vaultRoot = path.resolve(vaultRoot);
     this.store = store;
     this.embedder = embedder;
+    this.watcherAdapter = watcher;
+    this.fs = fs;
     this.chunker = new MarkdownChunker(new MarkdownPipeline());
   }
 
@@ -70,8 +96,7 @@ export class VaultIndexer {
   // ── Single-file operations ─────────────────────────────────────
 
   async indexFile(relativePath: string): Promise<void> {
-    const absPath = path.join(this.vaultRoot, relativePath);
-    const content = await fs.readFile(absPath, "utf-8");
+    const content = await this.fs.readNote(relativePath);
 
     const chunks = this.chunker.chunk(content);
     if (chunks.length === 0) {
@@ -104,7 +129,7 @@ export class VaultIndexer {
   // ── Bulk indexing ──────────────────────────────────────────────
 
   async indexAll(): Promise<void> {
-    const files = await this.listMdFiles(this.vaultRoot);
+    const files = await this.fs.listNotes();
     for (const file of files) {
       try {
         await this.indexFile(file);
@@ -112,23 +137,6 @@ export class VaultIndexer {
         // Skip files that fail to index and continue with the rest.
       }
     }
-  }
-
-  private async listMdFiles(dir: string): Promise<string[]> {
-    const entries = await fs.readdir(dir, {
-      recursive: true,
-      withFileTypes: true,
-    });
-    const mdFiles: string[] = [];
-    for (const entry of entries) {
-      if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
-      const entryDir =
-        entry.parentPath ??
-        (entry as unknown as { path: string }).path;
-      const fullPath = path.join(entryDir, entry.name);
-      mdFiles.push(path.relative(this.vaultRoot, fullPath));
-    }
-    return mdFiles.sort();
   }
 
   // ── Offline queue ──────────────────────────────────────────────
@@ -142,9 +150,10 @@ export class VaultIndexer {
     this.queue.clear();
 
     for (const relPath of paths) {
-      const absPath = path.join(this.vaultRoot, relPath);
       try {
-        await fs.access(absPath);
+        if (!(await this.fs.exists(relPath))) {
+          throw new Error("File not found");
+        }
         await this.indexFile(relPath);
       } catch {
         // File was deleted between enqueue and process
@@ -153,21 +162,41 @@ export class VaultIndexer {
     }
   }
 
+  private async drain(): Promise<void> {
+    if (this.isProcessing) return;
+    this.isProcessing = true;
+    try {
+      while (this.queue.size > 0) {
+        const paths = [...this.queue];
+        this.queue.clear();
+        for (const relPath of paths) {
+          try {
+            if (!(await this.fs.exists(relPath))) {
+              throw new Error("File not found");
+            }
+            await this.indexFile(relPath);
+          } catch {
+            this.failureCount++;
+            this.lastFailureTime = new Date();
+            this.lastFailureSource = relPath;
+            await this.removeFile(relPath);
+          }
+        }
+      }
+    } finally {
+      this.isProcessing = false;
+    }
+  }
+
   // ── File watching ──────────────────────────────────────────────
 
   async startWatching(options?: WatcherOptions): Promise<void> {
     const debounceMs = options?.debounceMs ?? 500;
 
-    this.watcher = chokidar.watch(this.vaultRoot, {
-      ignored: (filePath: string) => {
-        // Ignore non-.md files (but allow directories)
-        const ext = path.extname(filePath);
-        return ext !== "" && ext !== ".md";
-      },
+    this.watcherAdapter.watch(this.vaultRoot, {
       persistent: true,
-      ignoreInitial: true,
-      awaitWriteFinish: { stabilityThreshold: 100 },
     });
+    this.watcherActive = true;
 
     const handleChange = (absPath: string): void => {
       const relPath = path.relative(this.vaultRoot, absPath);
@@ -180,17 +209,19 @@ export class VaultIndexer {
       const timer = setTimeout(() => {
         this.debounceTimers.delete(relPath);
         this.enqueue(relPath);
+        void this.drain();
       }, debounceMs);
 
       this.debounceTimers.set(relPath, timer);
     };
 
-    this.watcher.on("add", handleChange);
-    this.watcher.on("change", handleChange);
-    this.watcher.on("unlink", (absPath: string) => {
+    this.watcherAdapter.on("add", handleChange);
+    this.watcherAdapter.on("change", handleChange);
+    this.watcherAdapter.on("unlink", (absPath: string) => {
       const relPath = path.relative(this.vaultRoot, absPath);
       if (!relPath.endsWith(".md")) return;
       this.enqueue(relPath);
+      void this.drain();
     });
   }
 
@@ -201,9 +232,33 @@ export class VaultIndexer {
     }
     this.debounceTimers.clear();
 
-    if (this.watcher) {
-      await this.watcher.close();
-      this.watcher = null;
+    if (this.watcherActive) {
+      await this.watcherAdapter.close();
+      this.watcherActive = false;
     }
+  }
+
+  async getHealthStatus(): Promise<IndexingHealthStatus> {
+    const indexingState: IndexingHealthStatus["indexingState"] = this.isProcessing
+      ? "indexing"
+      : this.watcherActive
+        ? "watching"
+        : this.failureCount > 0
+          ? "error"
+          : "idle";
+
+    const lastFailure =
+      this.lastFailureTime !== null && this.lastFailureSource !== null
+        ? { time: this.lastFailureTime.toISOString(), source: this.lastFailureSource }
+        : null;
+
+    return {
+      indexingState,
+      watcherState: this.watcherActive ? "active" : "stopped",
+      queueDepth: this.queue.size,
+      failureCount: this.failureCount,
+      lastFailure,
+      indexedDocuments: await this.store.size(),
+    };
   }
 }


### PR DESCRIPTION
…path rejection, SSE hardening, error sanitization, watcher fix, health status

- SafePath: reject absolute paths (POSIX, Windows drive, UNC, URL-encoded) before stripping
- LocalFileSystemAdapter: realpath-based symlink containment for all file ops; snip parent-walk for new writes
- VaultIndexer: fix watcher queue never draining; snip add drain() with isProcessing serialization guard
- VaultIndexer: refactor IO behind IFileSystemAdapter + IFileWatcher ports (ChokidarFileWatcher adapter)
- VaultIndexer: add getHealthStatus() with indexingState, watcherState, queueDepth, failureCount, lastFailure
- transport: bind SSE to 127.0.0.1 by default (HOST_BIND_ADDRESS env var for Docker); snip configurable body limit (BODY_LIMIT_BYTES, default 1mb); snip restrict CORS to localhost origins; snip add error middleware for 413/400/500 JSON responses
- mcp-tools: convert all plain Error throws to InvalidArgumentError; snip sanitize unexpected errors to generic message + server-side console.error; snip expose health fields in system.status, remove vaultRoot
- domain/errors: add AbsolutePathError, SymlinkEscapeError, InvalidArgumentError
- domain/interfaces: add IFileWatcher port interface

434 tests pass, lint clean, build clean