### PR TITLE
feat: add self-orienting context layer for zero-config agent routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D22-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
-[![Tests](https://img.shields.io/badge/tests-342%20passed-brightgreen?logo=vitest&logoColor=white)](#-testing)
+[![Tests](https://img.shields.io/badge/tests-516%20passed-brightgreen?logo=vitest&logoColor=white)](#-testing)
 [![mcp-markdown-vault MCP server](https://glama.ai/mcp/servers/wirux/mcp-markdown-vault/badges/score.svg)](https://glama.ai/mcp/servers/wirux/mcp-markdown-vault)
 
 </div>
@@ -195,6 +195,7 @@ The server selects an embedding provider automatically:
 | Variable | Default | Description |
 |---|---|---|
 | `VAULT_PATH` | `/vault` | Markdown vault directory |
+| `VAULT_CONTEXT` | `general markdown notes vault` | One-line description of vault scope; surfaced to connected agents via MCP instructions and tool descriptions |
 | `MCP_TRANSPORT_TYPE` | `stdio` | `stdio` (single client) or `sse` (multi-client HTTP) |
 | `PORT` | `3000` | HTTP port (SSE mode only) |
 | `OLLAMA_URL` | *(unset)* | Set to enable Ollama embeddings |
@@ -223,6 +224,88 @@ See [CLAUDE.md](CLAUDE.md) for detailed architecture docs and [CHANGELOG.md](CHA
 
 ---
 
+## Self-Orienting Context Layer
+
+When an MCP client connects, the server automatically provides vault context so connected agents can decide **when** to query this vault and **how** to use its tools — without explicit user instructions.
+
+### Making agents find your vault
+
+The single most important thing: **set `VAULT_CONTEXT` to describe what your vault contains.**
+
+```json
+{
+  "mcpServers": {
+    "markdown-vault": {
+      "command": "npx",
+      "args": ["-y", "@wirux/mcp-markdown-vault"],
+      "env": {
+        "VAULT_PATH": "/path/to/your/vault",
+        "VAULT_CONTEXT": "personal research notes on machine learning and distributed systems"
+      }
+    }
+  }
+}
+```
+
+This one-line description is injected into the MCP handshake, the `view` tool description, and resource headers. When a user asks the agent something related to "machine learning" or "distributed systems", the agent sees the scope match and queries the vault autonomously.
+
+Default: `general markdown notes vault` (too generic for reliable routing — always set a specific value).
+
+### How context is delivered
+
+The server uses four complementary mechanisms so behavior degrades gracefully across clients with different MCP feature support:
+
+| Mechanism | When | What the agent sees |
+|---|---|---|
+| **`instructions` field** | MCP handshake (session start) | Vault scope + tool dispatcher summary. Supported by Claude Desktop, Claude Code, Cursor. |
+| **MCP Resources** | On-demand via `ReadResource` | `vault://overview` (composed view with live stats + contract + overview), `vault://contract` (raw contract), `vault://stats` (live JSON) |
+| **First-call priming** | First `view` tool call per session | `_meta.vault_orientation` block with scope + hint to read `vault://overview` |
+| **`view` tool description** | Tool listing | Includes the `VAULT_CONTEXT` scope string for tool-selection matching |
+
+Even if a client supports none of these (rare), the agent still discovers vault content through normal tool use.
+
+### Two files: contract vs overview
+
+On first startup, the server creates two files in `<VAULT_PATH>/meta/`. Both are created once and **never overwritten** — they are fully yours to edit.
+
+#### `meta/contract.md` — Tool optimization (power users)
+
+Tells agents **how** to use the vault's tools efficiently. Pre-filled with sensible defaults:
+
+| Section | Purpose | Drives which tool |
+|---|---|---|
+| `## Frontmatter Schema` | YAML keys and types used across notes | `view.frontmatter_get`, `edit.frontmatter_set` |
+| `## Tag Conventions` | Tag naming rules and hierarchies | `view.global_search` query building |
+| `## Search Hints` | Which search action fits which query type | All `view` actions |
+| `## Naming Conventions` | File naming patterns | `vault.create` |
+| `## Note Template` | Default structure for new notes | `vault.create`, `vault.create_from_template` |
+
+Most users don't need to edit this. Power users can customize it to match their vault's specific conventions — agents read it via `vault://overview` and `vault://contract` resources on each request.
+
+> **Tip:** Add a `## Scope` section for a richer, multi-line vault description. Agents see it when reading `vault://overview` or `vault://contract` resources.
+
+#### `meta/overview.md` — Vault narrative (all users)
+
+Free-form description of **what** the vault currently contains. Created as an empty stub. Write here whatever helps an agent understand your vault's content: active projects, key topic areas, organizational philosophy.
+
+If the body is non-empty, its content is appended to the `vault://overview` resource that agents can read on demand.
+
+### Hot reload behavior
+
+| What changed | Effect | Restart needed? |
+|---|---|---|
+| `meta/contract.md` | Reflected in `vault://overview` and `vault://contract` on next read | No |
+| `meta/overview.md` | Reflected in `vault://overview` on next read | No |
+| `VAULT_CONTEXT` env var | Reflected in `instructions` field and `view` tool description | Yes |
+
+### Migration notes
+
+On first run after upgrade, `meta/contract.md` and `meta/overview.md` are auto-created if missing. Existing files are never overwritten. No breaking changes to tool APIs.
+
+If you have a `meta/contract.md` from other tooling with a different schema, review compatibility — the server-generated contract is dedicated to mcp-markdown-vault navigation hints.
+
+---
+
 ## 🚢 CI/CD & Release
 
 Fully automated via GitHub Actions and [Semantic Release](https://semantic-release.gitbook.io/):
@@ -241,7 +324,7 @@ Fully automated via GitHub Actions and [Semantic Release](https://semantic-relea
 
 ## 🧪 Testing
 
-**318 tests** across 31 files, written test-first (TDD).
+**516 tests** across 46 files, written test-first (TDD).
 
 ```bash
 npm test                                          # Run all tests

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { LocalFileSystemAdapter } from "./infrastructure/local-fs-adapter.js";
+import { InMemoryVectorStore } from "./infrastructure/vector-store/in-memory-vector-store.js";
+import { createMcpServer } from "./presentation/mcp-tools.js";
+import {
+  DEFAULT_VAULT_CONTEXT,
+  createServerFactory,
+  initializeVaultOrientation,
+  readVaultContext,
+} from "./index.js";
+import type {
+  IEmbeddingProvider,
+  IFileSystemAdapter,
+  IVectorStore,
+  VectorEntry,
+  VectorSearchResult,
+} from "./domain/interfaces/index.js";
+
+class FakeEmbedder implements IEmbeddingProvider {
+  readonly dimensions = 3;
+  readonly modelName = "fake";
+
+  async embed(text: string): Promise<number[]> {
+    const size = text.length || 1;
+    return [size, size / 2, size / 3];
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    return Promise.all(texts.map((text) => this.embed(text)));
+  }
+}
+
+class ThrowingVectorStore implements IVectorStore {
+  async upsert(_entry: VectorEntry): Promise<void> {
+    throw new Error("unused in test");
+  }
+
+  async search(_queryVector: number[], _k: number): Promise<VectorSearchResult[]> {
+    throw new Error("unused in test");
+  }
+
+  async delete(_docPath: string): Promise<void> {
+    throw new Error("unused in test");
+  }
+
+  async has(_docPath: string): Promise<boolean> {
+    throw new Error("unused in test");
+  }
+
+  async size(): Promise<number> {
+    return 0;
+  }
+
+  async save(): Promise<void> {}
+}
+
+const tmpDirs: string[] = [];
+const originalVaultContext = process.env["VAULT_CONTEXT"];
+
+beforeEach(() => {
+  delete process.env["VAULT_CONTEXT"];
+});
+
+afterEach(async () => {
+  if (originalVaultContext === undefined) {
+    delete process.env["VAULT_CONTEXT"];
+  } else {
+    process.env["VAULT_CONTEXT"] = originalVaultContext;
+  }
+
+  for (const dir of tmpDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function makeTempVault() {
+  const tmpPath = await mkdtemp(join(tmpdir(), "index-test-"));
+  const vaultPath = await realpath(tmpPath);
+  tmpDirs.push(vaultPath);
+  const fsAdapter = await LocalFileSystemAdapter.create(vaultPath);
+  return { vaultPath, fsAdapter };
+}
+
+async function readInitializeInstructions(server: ReturnType<typeof createMcpServer>) {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "index-test-client", version: "1.0.0" });
+
+  try {
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    return client.getInstructions();
+  } finally {
+    await client.close();
+    await server.close();
+  }
+}
+
+describe("src/index composition root helpers", () => {
+  it("uses default vault context when VAULT_CONTEXT is unset", () => {
+    delete process.env["VAULT_CONTEXT"];
+    expect(readVaultContext()).toBe(DEFAULT_VAULT_CONTEXT);
+  });
+
+  it("uses default vault context when VAULT_CONTEXT is empty string", () => {
+    process.env["VAULT_CONTEXT"] = "";
+    expect(readVaultContext()).toBe(DEFAULT_VAULT_CONTEXT);
+  });
+
+  it("uses provided VAULT_CONTEXT when set", () => {
+    process.env["VAULT_CONTEXT"] = "my research vault";
+    expect(readVaultContext()).toBe("my research vault");
+  });
+
+  it("auto-init on empty vault creates both meta files", async () => {
+    const { fsAdapter } = await makeTempVault();
+
+    const result = await initializeVaultOrientation({
+      fsAdapter,
+      vaultContext: readVaultContext({ VAULT_CONTEXT: "my research vault" }),
+      logger: { error: () => undefined },
+    });
+
+    expect(result.initResult.contractCreated).toBe(true);
+    expect(result.initResult.overviewCreated).toBe(true);
+    expect(await fsAdapter.exists("meta/contract.md")).toBe(true);
+    expect(await fsAdapter.exists("meta/overview.md")).toBe(true);
+  });
+
+  it("auto-init when meta files exist does not overwrite and does not fail", async () => {
+    const { fsAdapter } = await makeTempVault();
+    await fsAdapter.writeNote("meta/contract.md", "# Custom Contract");
+    await fsAdapter.writeNote("meta/overview.md", "# Custom Overview");
+
+    const result = await initializeVaultOrientation({
+      fsAdapter,
+      vaultContext: "my research vault",
+      logger: { error: () => undefined },
+    });
+
+    expect(result.initResult.contractCreated).toBe(false);
+    expect(result.initResult.overviewCreated).toBe(false);
+    expect(await fsAdapter.readNote("meta/contract.md")).toBe("# Custom Contract");
+    expect(await fsAdapter.readNote("meta/overview.md")).toBe("# Custom Overview");
+  });
+
+  it("auto-init failure still returns instructions and starts composition flow", async () => {
+    const { fsAdapter } = await makeTempVault();
+    const errors: unknown[][] = [];
+    const brokenFsAdapter: IFileSystemAdapter = {
+      listNotes: fsAdapter.listNotes.bind(fsAdapter),
+      readNote: fsAdapter.readNote.bind(fsAdapter),
+      exists: async () => false,
+      writeNote: async () => {
+        throw new Error("EROFS: read-only file system");
+      },
+      deleteNote: fsAdapter.deleteNote.bind(fsAdapter),
+      stat: fsAdapter.stat.bind(fsAdapter),
+    };
+
+    const result = await initializeVaultOrientation({
+      fsAdapter: brokenFsAdapter,
+      vaultContext: "my research vault",
+      logger: {
+        error: (...args: unknown[]) => {
+          errors.push(args);
+        },
+      },
+    });
+
+    expect(result.instructions.length).toBeGreaterThan(0);
+    expect(result.vaultScope).toBe("my research vault");
+    expect(errors).toEqual([]);
+  });
+
+  it("passes non-empty instructions to MCP server dependencies", async () => {
+    const { fsAdapter, vaultPath } = await makeTempVault();
+    const orientation = await initializeVaultOrientation({
+      fsAdapter,
+      vaultContext: "my research vault",
+      logger: { error: () => undefined },
+    });
+    const serverFactory = createServerFactory({
+      fsAdapter,
+      vectorStore: new InMemoryVectorStore(),
+      embedder: new FakeEmbedder(),
+      vaultRoot: vaultPath,
+      instructions: orientation.instructions,
+      vaultScope: orientation.vaultScope,
+    });
+
+    const instructions = await readInitializeInstructions(serverFactory());
+
+    expect(orientation.instructions.length).toBeGreaterThan(0);
+    expect(instructions).toBe(orientation.instructions);
+  });
+
+  it("vaultScope uses vaultContext directly without file I/O", async () => {
+    const { fsAdapter } = await makeTempVault();
+    const orientation = await initializeVaultOrientation({
+      fsAdapter,
+      vaultContext: "my research vault",
+      logger: { error: () => undefined },
+    });
+    expect(orientation.vaultScope).toBe("my research vault");
+  });
+
+  it("vaultScope falls back to default when vaultContext is empty", async () => {
+    const { fsAdapter } = await makeTempVault();
+    const orientation = await initializeVaultOrientation({
+      fsAdapter,
+      vaultContext: "",
+      logger: { error: () => undefined },
+    });
+    expect(orientation.vaultScope).toBe(DEFAULT_VAULT_CONTEXT);
+  });
+
+  it("vaultScope falls back to default when vaultContext is whitespace", async () => {
+    const { fsAdapter } = await makeTempVault();
+    const orientation = await initializeVaultOrientation({
+      fsAdapter,
+      vaultContext: "   ",
+      logger: { error: () => undefined },
+    });
+    expect(orientation.vaultScope).toBe(DEFAULT_VAULT_CONTEXT);
+  });
+
+  it("createServerFactory injects workflow per server instance while preserving orientation data", async () => {
+    const { fsAdapter, vaultPath } = await makeTempVault();
+    const orientation = await initializeVaultOrientation({
+      fsAdapter,
+      vaultContext: "factory vault",
+      logger: { error: () => undefined },
+    });
+    const vectorStore = new ThrowingVectorStore();
+    const serverFactory = createServerFactory({
+      fsAdapter,
+      vectorStore,
+      embedder: new FakeEmbedder(),
+      vaultRoot: vaultPath,
+      instructions: orientation.instructions,
+      vaultScope: orientation.vaultScope,
+    });
+
+    const serverA = serverFactory();
+    const serverB = serverFactory();
+
+    expect(serverA).not.toBe(serverB);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { pathToFileURL } from "node:url";
 import { LocalFileSystemAdapter } from "./infrastructure/local-fs-adapter.js";
 import { ChokidarFileWatcher } from "./infrastructure/chokidar-file-watcher.js";
 import { createVectorStore } from "./infrastructure/vector-store-factory.js";
@@ -11,15 +12,78 @@ import {
   StartupError,
 } from "./infrastructure/startup-checks.js";
 import type { IEmbeddingProvider } from "./domain/interfaces/index.js";
+import type { IFileSystemAdapter } from "./domain/interfaces/file-system-adapter.js";
 import { WorkflowStateMachine } from "./use-cases/workflow-state.js";
 import { VaultIndexer } from "./use-cases/vault-indexer.js";
 import { BacklinkIndexService } from "./use-cases/backlink-index.js";
 import { MarkdownPipeline } from "./use-cases/markdown-pipeline.js";
-import { createMcpServer } from "./presentation/mcp-tools.js";
+import { VaultAutoInitService, type AutoInitResult } from "./use-cases/vault-auto-init.js";
+import { composeInstructions } from "./use-cases/instructions-composer.js";
+import { createMcpServer, type McpDependencies } from "./presentation/mcp-tools.js";
 import {
   parseTransportType,
   startTransport,
 } from "./presentation/transport.js";
+
+export const DEFAULT_VAULT_CONTEXT = "general markdown notes vault";
+
+export function readVaultContext(env: NodeJS.ProcessEnv = process.env): string {
+  return env["VAULT_CONTEXT"] || DEFAULT_VAULT_CONTEXT;
+}
+
+export interface VaultOrientation {
+  initResult: AutoInitResult;
+  vaultScope: string;
+  instructions: string;
+}
+
+export async function initializeVaultOrientation(deps: {
+  fsAdapter: IFileSystemAdapter;
+  vaultContext: string;
+  logger?: Pick<Console, "error">;
+}): Promise<VaultOrientation> {
+  const logger = deps.logger ?? console;
+  const autoInit = new VaultAutoInitService({
+    fsAdapter: deps.fsAdapter,
+    vaultContext: deps.vaultContext,
+  });
+  const initResult = await autoInit.initialize().catch((err: unknown) => {
+    logger.error("Vault auto-init failed:", err);
+    return {
+      contractCreated: false,
+      overviewCreated: false,
+      warnings: [],
+    } satisfies AutoInitResult;
+  });
+
+  if (initResult.contractCreated) {
+    logger.error("meta/contract.md created");
+  }
+  if (initResult.overviewCreated) {
+    logger.error("meta/overview.md created");
+  }
+  for (const warning of initResult.warnings) {
+    logger.error(`[warn] ${warning}`);
+  }
+
+  const vaultScope = deps.vaultContext.trim() || DEFAULT_VAULT_CONTEXT;
+
+  return {
+    initResult,
+    vaultScope,
+    instructions: composeInstructions(vaultScope),
+  };
+}
+
+export function createServerFactory(
+  deps: Omit<McpDependencies, "workflow">,
+): () => ReturnType<typeof createMcpServer> {
+  return () =>
+    createMcpServer({
+      ...deps,
+      workflow: new WorkflowStateMachine(),
+    });
+}
 
 /**
  * Strategy: pick the embedding provider based on environment.
@@ -68,6 +132,7 @@ async function createEmbeddingProvider(): Promise<IEmbeddingProvider> {
 
 async function main(): Promise<void> {
   const vaultRoot = process.env["VAULT_PATH"] ?? "/vault";
+  const vaultContext = readVaultContext();
   const transportType = parseTransportType(
     process.env["MCP_TRANSPORT_TYPE"],
   );
@@ -84,6 +149,10 @@ async function main(): Promise<void> {
 
   // Shared dependencies (reused across all client connections)
   const fsAdapter = await LocalFileSystemAdapter.create(vaultRoot);
+  const { vaultScope, instructions } = await initializeVaultOrientation({
+    fsAdapter,
+    vaultContext,
+  });
 
   // ── Startup health checks ──────────────────────────────────────
   if (ollamaUrl !== undefined) {
@@ -130,16 +199,16 @@ async function main(): Promise<void> {
 
   // Server factory: each connection gets its own McpServer + WorkflowStateMachine.
   // Shared deps (fs, vectors, embedder, backlinkIndex, indexer) are captured by closure.
-  const serverFactory = () =>
-    createMcpServer({
-      fsAdapter,
-      vectorStore,
-      embedder,
-      workflow: new WorkflowStateMachine(),
-      vaultRoot,
-      backlinkIndex,
-      indexer,
-    });
+  const serverFactory = createServerFactory({
+    fsAdapter,
+    vectorStore,
+    embedder,
+    vaultRoot,
+    backlinkIndex,
+    indexer,
+    instructions,
+    vaultScope,
+  });
 
   // Vector indexing + backlinks on startup
   indexer
@@ -193,12 +262,23 @@ async function main(): Promise<void> {
   }, 60_000).unref();
 }
 
-main().catch((err) => {
-  if (err instanceof StartupError) {
-    console.error(`\nStartup check failed: ${err.message}`);
-    console.error(`  → ${err.hint}\n`);
-  } else {
-    console.error("Fatal:", err);
+function isDirectExecution(): boolean {
+  const entryPoint = process.argv[1];
+  if (!entryPoint) {
+    return false;
   }
-  process.exit(1);
-});
+
+  return import.meta.url === pathToFileURL(entryPoint).href;
+}
+
+if (isDirectExecution()) {
+  main().catch((err) => {
+    if (err instanceof StartupError) {
+      console.error(`\nStartup check failed: ${err.message}`);
+      console.error(`  → ${err.hint}\n`);
+    } else {
+      console.error("Fatal:", err);
+    }
+    process.exit(1);
+  });
+}

--- a/src/presentation/mcp-tools.test.ts
+++ b/src/presentation/mcp-tools.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import fs from "node:fs/promises";
-import path from "node:path";
-import os from "node:os";
+import fs from "fs/promises";
+import path from "path";
+import os from "os";
 import { createMcpServer, type McpDependencies } from "./mcp-tools.js";
 import { LocalFileSystemAdapter } from "../infrastructure/local-fs-adapter.js";
 import { InMemoryVectorStore } from "../infrastructure/vector-store/in-memory-vector-store.js";
@@ -13,10 +13,25 @@ import { BacklinkIndexService } from "../use-cases/backlink-index.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 
+type TextResource = { uri: string; text: string; mimeType?: string };
+
+function getTextResourceContent(resource: unknown): TextResource {
+  if (
+    typeof resource === "object"
+    && resource !== null
+    && "text" in resource
+    && typeof (resource as { text: unknown }).text === "string"
+  ) {
+    return resource as TextResource;
+  }
+  throw new Error("Expected text resource content");
+}
+
 // ── Fake embedding provider ──────────────────────────────────────
 
 class FakeEmbedder implements IEmbeddingProvider {
   readonly dimensions = 3;
+  readonly modelName = "fake";
   async embed(text: string): Promise<number[]> {
     const h = [...text].reduce((s, c) => ((s << 5) - s + c.charCodeAt(0)) | 0, 0);
     return [Math.sin(h), Math.cos(h), Math.sin(h * 2)];
@@ -66,7 +81,16 @@ beforeEach(async () => {
     { path: "daily/2024-01-01.md", content: "# Daily Note\n\nToday I learned about MCP. See [[hello]].\n" },
   ]);
 
-  deps = { fsAdapter, vectorStore, embedder, workflow, vaultRoot: tmpDir, backlinkIndex };
+  deps = {
+    fsAdapter,
+    vectorStore,
+    embedder,
+    workflow,
+    vaultRoot: tmpDir,
+    backlinkIndex,
+    instructions: "test instructions",
+    vaultScope: "test vault",
+  };
 
   const server = createMcpServer(deps);
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -106,6 +130,103 @@ describe("MCP Server — tool listing", () => {
     for (const tool of result.tools) {
       expect(tool.description).toBeTruthy();
     }
+  });
+
+  it("view tool description includes vault scope text", async () => {
+    const result = await client.listTools();
+    const viewTool = result.tools.find((tool) => tool.name === "view");
+    expect(viewTool?.description).toContain("Vault scope: test vault");
+  });
+});
+
+describe("MCP Server — resources and priming", () => {
+  it("listResources returns 3 resources with expected URIs", async () => {
+    const result = await client.listResources();
+    const uris = result.resources.map((resource) => resource.uri).sort();
+    expect(uris).toEqual(["vault://contract", "vault://overview", "vault://stats"]);
+  });
+
+  it("readResource overview returns markdown starting with vault heading", async () => {
+    await fs.mkdir(path.join(tmpDir, "meta"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, "meta/overview.md"),
+      "---\ntitle: Overview\n---\n\n# Overview\n\nHelpful overview content.\n",
+    );
+
+    const result = await client.readResource({ uri: "vault://overview" });
+    const content = result.contents[0];
+    expect(content).toBeDefined();
+    expect(getTextResourceContent(content).text.startsWith("# Vault:")).toBe(true);
+  });
+
+  it("readResource contract returns contract.md content", async () => {
+    await fs.mkdir(path.join(tmpDir, "meta"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, "meta/contract.md"),
+      "# Contract\n\nVault contract content.\n",
+    );
+
+    const result = await client.readResource({ uri: "vault://contract" });
+    const content = result.contents[0];
+    expect(content).toBeDefined();
+    expect(getTextResourceContent(content).text).toBe("# Contract\n\nVault contract content.\n");
+  });
+
+  it("readResource stats returns valid JSON with expected fields", async () => {
+    const result = await client.readResource({ uri: "vault://stats" });
+    const content = result.contents[0];
+    expect(content).toBeDefined();
+    const parsed = JSON.parse(getTextResourceContent(content).text) as {
+      fileCount: number;
+      indexStatus: string;
+      embeddingProvider: string;
+    };
+
+    expect(parsed.fileCount).toBe(2);
+    expect(parsed.indexStatus).toBe("not started");
+    expect(parsed.embeddingProvider).toBe("fake");
+  });
+
+  it("first view tool call returns vault orientation priming metadata", async () => {
+    const result = await client.callTool({
+      name: "view",
+      arguments: { action: "backlinks", path: "hello.md" },
+    });
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0]!.text);
+
+    expect(parsed.result._meta.vault_orientation).toEqual({
+      scope: "test vault",
+      hint: "Read vault://overview resource or meta/contract.md for full conventions.",
+    });
+  });
+
+  it("second view tool call does not return vault orientation priming metadata", async () => {
+    await client.callTool({
+      name: "view",
+      arguments: { action: "backlinks", path: "hello.md" },
+    });
+
+    const secondResult = await client.callTool({
+      name: "view",
+      arguments: { action: "backlinks", path: "hello.md" },
+    });
+    const parsed = JSON.parse((secondResult.content as Array<{ type: string; text: string }>)[0]!.text);
+
+    expect(parsed.result._meta).toBeUndefined();
+  });
+
+  it("vault tool first call does not return vault orientation priming metadata", async () => {
+    const result = await client.callTool({
+      name: "vault",
+      arguments: { action: "list" },
+    });
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0]!.text);
+
+    expect(parsed.result._meta).toBeUndefined();
+  });
+
+  it("server initialization result includes non-empty instructions", () => {
+    expect(client.getInstructions()).toBe("test instructions");
   });
 });
 
@@ -179,6 +300,13 @@ describe("vault tool", () => {
 // ── view tool ─────────────────────────────────────────────────────
 
 describe("view tool", () => {
+  beforeEach(async () => {
+    await client.callTool({
+      name: "view",
+      arguments: { action: "backlinks", path: "hello.md" },
+    });
+  });
+
   it("retrieves fragments for a query", async () => {
     const result = await client.callTool({
       name: "view",

--- a/src/presentation/mcp-tools.ts
+++ b/src/presentation/mcp-tools.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ServerOptions } from "@modelcontextprotocol/sdk/server/index.js";
 import { z } from "zod";
 import type { IFileSystemAdapter } from "../domain/interfaces/file-system-adapter.js";
 import type { IEmbeddingProvider, IVectorStore } from "../domain/interfaces/index.js";
@@ -25,7 +26,9 @@ import { VaultIndexer } from "../use-cases/vault-indexer.js";
 import { MarkdownFileRepository } from "../infrastructure/markdown-file-repository.js";
 import { RegexTemplateEngine } from "../infrastructure/regex-template-engine.js";
 import { UnifiedDiffService } from "../infrastructure/diff-service.js";
-import { DomainError, InvalidArgumentError } from "../domain/errors/index.js";
+import { DomainError, InvalidArgumentError, NoteNotFoundError } from "../domain/errors/index.js";
+import { VaultStatsComposer } from "../use-cases/vault-stats.js";
+import { VaultOverviewResourceComposer } from "../use-cases/vault-resource-overview.js";
 
 export interface McpDependencies {
   fsAdapter: IFileSystemAdapter;
@@ -35,19 +38,78 @@ export interface McpDependencies {
   vaultRoot: string;
   backlinkIndex?: BacklinkIndexService | undefined;
   indexer?: VaultIndexer | undefined;
+  instructions?: string | undefined;
+  vaultScope?: string | undefined;
 }
 
 /**
  * Creates and configures the MCP server with all 5 semantic tools.
  */
 export function createMcpServer(deps: McpDependencies): McpServer {
-  const server = new McpServer({
-    name: "markdown-vault-mcp",
-    version: "0.1.0",
-  });
+  let serverOptions: ServerOptions | undefined;
+  if (deps.instructions) {
+    serverOptions = { instructions: deps.instructions };
+  }
+  const server = new McpServer(
+    { name: "markdown-vault-mcp", version: "0.1.0" },
+    serverOptions,
+  );
 
   const pipeline = new MarkdownPipeline();
   const retriever = new FragmentRetriever(pipeline);
+
+  const statsComposerDeps: ConstructorParameters<typeof VaultStatsComposer>[0] = {
+    fsAdapter: deps.fsAdapter,
+    embedder: deps.embedder,
+  };
+  if (deps.indexer) {
+    statsComposerDeps.indexer = deps.indexer;
+  }
+  const statsComposer = new VaultStatsComposer(statsComposerDeps);
+  const overviewComposer = new VaultOverviewResourceComposer({
+    fsAdapter: deps.fsAdapter,
+    statsComposer,
+    vaultScope: deps.vaultScope ?? "general markdown notes vault",
+  });
+
+  server.registerResource(
+    "vault-overview",
+    "vault://overview",
+    { title: "Vault Overview", description: "Vault scope, live stats, navigation contract, and overview.", mimeType: "text/markdown" },
+    async () => {
+      const text = await overviewComposer.compose();
+      return { contents: [{ uri: "vault://overview", text, mimeType: "text/markdown" }] };
+    },
+  );
+
+  server.registerResource(
+    "vault-contract",
+    "vault://contract",
+    { title: "Vault Contract", description: "Raw vault navigation contract (meta/contract.md).", mimeType: "text/markdown" },
+    async () => {
+      try {
+        const text = await deps.fsAdapter.readNote("meta/contract.md");
+        return { contents: [{ uri: "vault://contract", text, mimeType: "text/markdown" }] };
+      } catch (err) {
+        if (err instanceof NoteNotFoundError) {
+          return { contents: [{ uri: "vault://contract", text: "meta/contract.md not found.", mimeType: "text/markdown" }] };
+        }
+        throw err;
+      }
+    },
+  );
+
+  server.registerResource(
+    "vault-stats",
+    "vault://stats",
+    { title: "Vault Stats", description: "Live vault statistics as JSON.", mimeType: "application/json" },
+    async () => {
+      const stats = await statsComposer.computeStats();
+      return { contents: [{ uri: "vault://stats", text: JSON.stringify(stats), mimeType: "application/json" }] };
+    },
+  );
+
+  let firstViewCall = true;
 
   // ── vault tool ──────────────────────────────────────────────────
 
@@ -299,7 +361,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
   server.registerTool("view", {
     title: "View",
     description:
-      "View and search notes. Actions: search (single-file fragment retrieval), global_search (cross-vault keyword search), semantic_search (cross-vault vector+lexical hybrid), outline (heading structure), read (full content or by heading), frontmatter_get (read YAML frontmatter), bulk_read (read multiple files/headings in one call), backlinks (find all notes linking to a given path).",
+      `Read and search markdown notes. Vault scope: ${deps.vaultScope ?? "general markdown notes vault"}.\nActions: search (heading-aware fragment retrieval with TF-IDF + proximity), semantic_search (vector + lexical hybrid for conceptual queries), global_search (cross-vault exact-match grep), outline (file or directory structure tree), read (full file or single section by heading), frontmatter_get (parse YAML frontmatter), bulk_read (read multiple files/headings in one call), backlinks (find all notes linking to a given path).`,
     inputSchema: {
       action: z.enum(["search", "global_search", "semantic_search", "outline", "read", "frontmatter_get", "bulk_read", "backlinks"]),
       path: z.string().optional(),
@@ -316,7 +378,11 @@ export function createMcpServer(deps: McpDependencies): McpServer {
     },
   }, async ({ action, path: notePath, query, maxChunks, heading, headingDepth, directory, items }) => {
     return wrapTool(deps.workflow, "view", async () => {
-      switch (action) {
+      const isPriming = firstViewCall;
+      if (firstViewCall) firstViewCall = false;
+
+      const actionResult = await (async () => {
+        switch (action) {
         case "search": {
           if (!notePath) throw new InvalidArgumentError("path");
           if (!query) throw new InvalidArgumentError("query");
@@ -408,7 +474,21 @@ export function createMcpServer(deps: McpDependencies): McpServer {
         }
         default:
           throw new InvalidArgumentError("action");
+        }
+      })();
+
+      if (isPriming) {
+        return Object.assign({}, actionResult as object, {
+          _meta: {
+            vault_orientation: {
+              scope: deps.vaultScope ?? "general markdown notes vault",
+              hint: "Read vault://overview resource or meta/contract.md for full conventions.",
+            },
+          },
+        });
       }
+
+      return actionResult;
     });
   });
 

--- a/src/use-cases/contract-template.test.ts
+++ b/src/use-cases/contract-template.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { generateContractTemplate } from "./contract-template.js";
+
+describe("generateContractTemplate", () => {
+  const ts = "2026-01-15T10:00:00.000Z";
+
+  it("includes schema_version: 1 in frontmatter", () => {
+    const result = generateContractTemplate("my notes", ts);
+    expect(result).toContain("schema_version: 1");
+  });
+
+  it("includes generated_by: mcp-markdown-vault in frontmatter", () => {
+    const result = generateContractTemplate("my notes", ts);
+    expect(result).toContain("generated_by: mcp-markdown-vault");
+  });
+
+  it("includes generated_at matching the provided timestamp", () => {
+    const result = generateContractTemplate("my notes", ts);
+    expect(result).toContain(`generated_at: ${ts}`);
+  });
+
+  it("includes the main heading", () => {
+    const result = generateContractTemplate("my notes", ts);
+    expect(result).toContain("# Vault Contract");
+  });
+
+  it("includes all 5 section headings", () => {
+    const result = generateContractTemplate("my notes", ts);
+    expect(result).toContain("## Frontmatter Schema");
+    expect(result).toContain("## Tag Conventions");
+    expect(result).toContain("## Search Hints");
+    expect(result).toContain("## Naming Conventions");
+    expect(result).toContain("## Note Template");
+  });
+
+  it("does NOT include redundant sections covered by tools", () => {
+    const result = generateContractTemplate("my notes", ts);
+    // Scope → covered by VAULT_CONTEXT env var + overview.md
+    // Directory Layout → covered by view.outline + vault://stats
+    // Workflow States → covered by workflow.status tool
+    expect(result).not.toMatch(/^## Scope$/m);
+    expect(result).not.toContain("## Directory Layout");
+    expect(result).not.toContain("## Workflow States");
+  });
+
+  it("mentions Scope option in HTML comment for power users", () => {
+    const result = generateContractTemplate("my notes", ts);
+    expect(result).toContain("## Scope");
+    expect(result).toContain("Power users");
+  });
+
+  it("does not use vaultContext in output (no Scope section)", () => {
+    const result = generateContractTemplate("my custom scope", ts);
+    expect(result).not.toContain("my custom scope");
+  });
+
+  it("includes HTML comments as inline guidance", () => {
+    const result = generateContractTemplate("my notes", ts);
+    expect(result).toContain("<!--");
+    expect(result).toContain("-->");
+  });
+
+  it("Search Hints section contains all search action recommendations", () => {
+    const result = generateContractTemplate("my notes", ts);
+    expect(result).toContain("semantic_search");
+    expect(result).toContain("global_search");
+    expect(result).toContain("view.read");
+    expect(result).toContain("view.outline");
+    expect(result).toContain("view.frontmatter_get");
+    expect(result).toContain("view.backlinks");
+    expect(result).toContain("view.bulk_read");
+  });
+
+  it("different timestamps produce different generated_at values", () => {
+    const r1 = generateContractTemplate("v", "2026-01-01T00:00:00.000Z");
+    const r2 = generateContractTemplate("v", "2026-06-01T00:00:00.000Z");
+    expect(r1).toContain("2026-01-01T00:00:00.000Z");
+    expect(r2).toContain("2026-06-01T00:00:00.000Z");
+  });
+
+  it("includes pre-filled frontmatter schema with practical defaults", () => {
+    const result = generateContractTemplate("my notes", ts);
+    expect(result).toContain("`title`: string");
+    expect(result).toContain("`tags`: string[]");
+    expect(result).toContain("`type`: enum");
+    expect(result).toContain("`created`: ISO 8601 date");
+    expect(result).toContain("`status`: enum");
+  });
+
+  it("includes pre-filled tag conventions", () => {
+    const result = generateContractTemplate("my notes", ts);
+    expect(result).toContain("hyphen-separated");
+    expect(result).toContain("Hierarchical");
+  });
+
+  it("includes pre-filled naming conventions with length constraint", () => {
+    const result = generateContractTemplate("my notes", ts);
+    expect(result).toContain("kebab-case.md");
+    expect(result).toContain("2–5 words");
+    expect(result).toContain("no prefixes");
+  });
+
+  it("includes a Note Template section with markdown scaffold", () => {
+    const result = generateContractTemplate("my notes", ts);
+    expect(result).toContain("## Note Template");
+    expect(result).toContain("title: {{Title}}");
+    expect(result).toContain("tags: []");
+    expect(result).toContain("type: note");
+    expect(result).toContain("status: draft");
+    expect(result).toContain("## Context");
+    expect(result).toContain("## Content");
+  });
+});

--- a/src/use-cases/contract-template.ts
+++ b/src/use-cases/contract-template.ts
@@ -1,0 +1,73 @@
+export function generateContractTemplate(
+  _vaultContext: string,
+  timestamp: string,
+): string {
+  return `---
+schema_version: 1
+generated_by: mcp-markdown-vault
+generated_at: ${timestamp}
+---
+
+# Vault Contract
+
+<!-- Edit freely. The server creates this file once and never overwrites it.
+     Connected agents read it to route queries and choose tool actions.
+     Power users: add ## Scope here for a richer vault description visible to agents. -->
+
+## Frontmatter Schema
+
+<!-- Used by view.frontmatter_get and edit.frontmatter_set. -->
+
+- \`title\`: string — note title
+- \`tags\`: string[] — categorization tags (e.g. \`[research, draft]\`)
+- \`type\`: enum — \`note\` | \`reference\` | \`log\` | \`template\`
+- \`created\`: ISO 8601 date — creation timestamp
+- \`updated\`: ISO 8601 date — last modification timestamp
+- \`status\`: enum — \`draft\` | \`in_progress\` | \`done\`
+
+## Tag Conventions
+
+- Lowercase, hyphen-separated: \`machine-learning\`, \`project-alpha\`
+- Hierarchical via \`/\` separator: \`lang/python\`, \`lang/typescript\`
+
+## Search Hints
+
+- Conceptual / fuzzy queries → \`view.semantic_search\`
+- Exact phrases or regex patterns → \`view.global_search\`
+- Reading a specific section → \`view.read\` with \`heading\` parameter
+- Structure overview → \`view.outline\`
+- YAML metadata → \`view.frontmatter_get\`
+- Incoming links to a note → \`view.backlinks\`
+- Reading multiple files at once → \`view.bulk_read\`
+
+## Naming Conventions
+
+- Files: \`kebab-case.md\`, 2–5 words, no prefixes (e.g. \`project-plan.md\`, not \`note-project-plan.md\`)
+- Directories: \`kebab-case/\` (e.g. \`daily-notes/\`, \`project-docs/\`)
+
+## Note Template
+
+<!-- Default structure for new notes. Agents use this when creating files
+     via vault.create. Customize to match your preferred note format. -->
+
+\`\`\`markdown
+---
+title: {{Title}}
+tags: []
+type: note
+created: {{YYYY-MM-DD}}
+status: draft
+---
+
+# {{Title}}
+
+## Context
+
+{{What problem or topic this note addresses.}}
+
+## Content
+
+{{Main body of the note.}}
+\`\`\`
+`;
+}

--- a/src/use-cases/instructions-composer.test.ts
+++ b/src/use-cases/instructions-composer.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { composeInstructions } from "./instructions-composer.js";
+
+describe("composeInstructions", () => {
+  it("starts with headless markdown vault server sentence", () => {
+    const result = composeInstructions("my vault");
+    expect(result).toMatch(/^Headless markdown vault MCP server\./);
+  });
+
+  it("includes vault scope in output", () => {
+    const result = composeInstructions("my research vault");
+    expect(result).toContain("Vault scope: my research vault");
+  });
+
+  it("lists all 5 tool dispatchers", () => {
+    const result = composeInstructions("test");
+    expect(result).toContain("view:");
+    expect(result).toContain("vault:");
+    expect(result).toContain("edit:");
+    expect(result).toContain("workflow:");
+    expect(result).toContain("system:");
+  });
+
+  it("includes search guidance", () => {
+    const result = composeInstructions("test");
+    expect(result).toContain("semantic_search");
+    expect(result).toContain("global_search");
+    expect(result).toContain("outline");
+  });
+
+  it("mentions vault://overview resource", () => {
+    const result = composeInstructions("test");
+    expect(result).toContain("vault://overview");
+  });
+
+  it("is under 2048 characters for normal scope", () => {
+    const result = composeInstructions("my vault");
+    expect(result.length).toBeLessThanOrEqual(2048);
+  });
+
+  it("is capped at 2048 characters for very long scope", () => {
+    const longScope = "x".repeat(2000);
+    const result = composeInstructions(longScope);
+    expect(result.length).toBeLessThanOrEqual(2048);
+  });
+
+  it("sanitizes backticks in vault scope", () => {
+    const result = composeInstructions("my `special` vault");
+    expect(result).toContain("my \\`special\\` vault");
+  });
+
+  it("sanitizes brackets in vault scope", () => {
+    const result = composeInstructions("vault [notes]");
+    expect(result).toContain("vault \\[notes\\]");
+  });
+
+  it("uses default scope when empty string provided", () => {
+    const result = composeInstructions("");
+    expect(result).toContain("general markdown notes vault");
+  });
+});

--- a/src/use-cases/instructions-composer.ts
+++ b/src/use-cases/instructions-composer.ts
@@ -1,0 +1,25 @@
+import { sanitizeForMarkdown } from "./markdown-utils.js";
+
+const MAX_INSTRUCTIONS_LENGTH = 2048;
+
+export function composeInstructions(vaultScope: string): string {
+  const safeScope = sanitizeForMarkdown(vaultScope.trim() || "general markdown notes vault");
+
+  const instructions = `Headless markdown vault MCP server. Vault scope: ${safeScope}.
+
+Tool dispatchers (action-based — pass \`action\` parameter to each):
+- view: read and search content (search, semantic_search, global_search, outline, read, frontmatter_get, bulk_read, backlinks)
+- vault: CRUD on .md files (list, read, create, update, delete, stat, create_from_template)
+- edit: surgical AST-based modifications (append, prepend, replace, line_replace, string_replace, frontmatter_set; supports dryRun)
+- workflow: Petri-net state machine (status, transition, history, reset)
+- system: server status (status, reindex)
+
+For full vault conventions (directory layout, frontmatter schema, tag conventions, search hints), read the \`vault://overview\` resource if your client supports MCP resources, or check \`meta/contract.md\` directly via \`view\` action=\`read\`.
+
+Search guidance: use \`semantic_search\` for conceptual or fuzzy queries, \`global_search\` for exact phrases, \`outline\` for structure exploration before search.`;
+
+  if (instructions.length > MAX_INSTRUCTIONS_LENGTH) {
+    return instructions.slice(0, MAX_INSTRUCTIONS_LENGTH);
+  }
+  return instructions;
+}

--- a/src/use-cases/markdown-utils.ts
+++ b/src/use-cases/markdown-utils.ts
@@ -1,0 +1,3 @@
+export function sanitizeForMarkdown(text: string): string {
+  return text.replace(/[`[\]]/g, (c) => `\\${c}`);
+}

--- a/src/use-cases/overview-template.test.ts
+++ b/src/use-cases/overview-template.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { generateOverviewStub } from "./overview-template.js";
+
+describe("generateOverviewStub", () => {
+  const ts = "2026-01-15T10:00:00.000Z";
+
+  it("includes schema_version: 1 in frontmatter", () => {
+    expect(generateOverviewStub(ts)).toContain("schema_version: 1");
+  });
+
+  it("includes generated_by: mcp-markdown-vault in frontmatter", () => {
+    expect(generateOverviewStub(ts)).toContain("generated_by: mcp-markdown-vault");
+  });
+
+  it("includes managed_by: user in frontmatter", () => {
+    expect(generateOverviewStub(ts)).toContain("managed_by: user");
+  });
+
+  it("includes generated_at matching the timestamp param", () => {
+    expect(generateOverviewStub(ts)).toContain(`generated_at: ${ts}`);
+  });
+
+  it("includes the main heading", () => {
+    expect(generateOverviewStub(ts)).toContain("# Vault Overview");
+  });
+
+  it("includes an HTML comment indicating user-controlled nature", () => {
+    const result = generateOverviewStub(ts);
+    expect(result).toContain("<!--");
+    expect(result).toContain("user-controlled");
+  });
+
+  it("different timestamps produce different generated_at values", () => {
+    const r1 = generateOverviewStub("2026-01-01T00:00:00.000Z");
+    const r2 = generateOverviewStub("2026-06-01T00:00:00.000Z");
+    expect(r1).toContain("2026-01-01T00:00:00.000Z");
+    expect(r2).toContain("2026-06-01T00:00:00.000Z");
+  });
+});

--- a/src/use-cases/overview-template.ts
+++ b/src/use-cases/overview-template.ts
@@ -1,0 +1,15 @@
+export function generateOverviewStub(timestamp: string): string {
+  return `---
+schema_version: 1
+generated_by: mcp-markdown-vault
+generated_at: ${timestamp}
+managed_by: user
+---
+
+# Vault Overview
+
+<!-- Free-form narrative about this vault's current contents and state.
+     Fully user-controlled — the server never modifies this file after creation.
+     Leave empty if you don't want to maintain it manually. -->
+`;
+}

--- a/src/use-cases/vault-auto-init.test.ts
+++ b/src/use-cases/vault-auto-init.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm, realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalFileSystemAdapter } from "../infrastructure/local-fs-adapter.js";
+import { VaultAutoInitService } from "./vault-auto-init.js";
+
+const tmpDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tmpDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function makeTempVault() {
+  const tmpPath = await mkdtemp(join(tmpdir(), "vault-auto-init-test-"));
+  const vaultPath = await realpath(tmpPath);
+  tmpDirs.push(vaultPath);
+  const adapter = await LocalFileSystemAdapter.create(vaultPath);
+  return { adapter };
+}
+
+describe("VaultAutoInitService", () => {
+  it("creates both meta files in empty vault", async () => {
+    const { adapter } = await makeTempVault();
+    const service = new VaultAutoInitService({ fsAdapter: adapter, vaultContext: "test vault" });
+    const result = await service.initialize();
+    expect(result.contractCreated).toBe(true);
+    expect(result.overviewCreated).toBe(true);
+    expect(result.warnings).toEqual([]);
+    expect(await adapter.exists("meta/contract.md")).toBe(true);
+    expect(await adapter.exists("meta/overview.md")).toBe(true);
+  });
+
+  it("emits warning when vault has existing .md files but no contract.md", async () => {
+    const { adapter } = await makeTempVault();
+    await adapter.writeNote("notes/existing.md", "# Existing");
+    const service = new VaultAutoInitService({ fsAdapter: adapter, vaultContext: "test" });
+    const result = await service.initialize();
+    expect(result.contractCreated).toBe(true);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings[0]).toContain("non-empty vault");
+  });
+
+  it("does not overwrite existing contract.md", async () => {
+    const { adapter } = await makeTempVault();
+    await adapter.writeNote("meta/contract.md", "# My Custom Contract");
+    const service = new VaultAutoInitService({ fsAdapter: adapter, vaultContext: "test" });
+    const result = await service.initialize();
+    expect(result.contractCreated).toBe(false);
+    const content = await adapter.readNote("meta/contract.md");
+    expect(content).toBe("# My Custom Contract");
+  });
+
+  it("does not overwrite existing overview.md", async () => {
+    const { adapter } = await makeTempVault();
+    await adapter.writeNote("meta/overview.md", "# My Overview");
+    const service = new VaultAutoInitService({ fsAdapter: adapter, vaultContext: "test" });
+    const result = await service.initialize();
+    expect(result.overviewCreated).toBe(false);
+    const content = await adapter.readNote("meta/overview.md");
+    expect(content).toBe("# My Overview");
+  });
+
+  it("returns both false when both files already exist", async () => {
+    const { adapter } = await makeTempVault();
+    await adapter.writeNote("meta/contract.md", "contract");
+    await adapter.writeNote("meta/overview.md", "overview");
+    const service = new VaultAutoInitService({ fsAdapter: adapter, vaultContext: "test" });
+    const result = await service.initialize();
+    expect(result.contractCreated).toBe(false);
+    expect(result.overviewCreated).toBe(false);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("creates only overview when contract already exists", async () => {
+    const { adapter } = await makeTempVault();
+    await adapter.writeNote("meta/contract.md", "contract");
+    const service = new VaultAutoInitService({ fsAdapter: adapter, vaultContext: "test" });
+    const result = await service.initialize();
+    expect(result.contractCreated).toBe(false);
+    expect(result.overviewCreated).toBe(true);
+  });
+
+  it("creates only contract when overview already exists", async () => {
+    const { adapter } = await makeTempVault();
+    await adapter.writeNote("meta/overview.md", "overview");
+    const service = new VaultAutoInitService({ fsAdapter: adapter, vaultContext: "test" });
+    const result = await service.initialize();
+    expect(result.contractCreated).toBe(true);
+    expect(result.overviewCreated).toBe(false);
+  });
+
+  it("generated contract contains expected structure", async () => {
+    const { adapter } = await makeTempVault();
+    const service = new VaultAutoInitService({ fsAdapter: adapter, vaultContext: "my research notes" });
+    await service.initialize();
+    const content = await adapter.readNote("meta/contract.md");
+    expect(content).toContain("# Vault Contract");
+    expect(content).toContain("## Frontmatter Schema");
+    expect(content).toContain("## Note Template");
+  });
+
+  it("generated overview contains managed_by: user in frontmatter", async () => {
+    const { adapter } = await makeTempVault();
+    const service = new VaultAutoInitService({ fsAdapter: adapter, vaultContext: "test" });
+    await service.initialize();
+    const content = await adapter.readNote("meta/overview.md");
+    expect(content).toContain("managed_by: user");
+  });
+
+  it("is idempotent — running twice does not throw or corrupt", async () => {
+    const { adapter } = await makeTempVault();
+    const service = new VaultAutoInitService({ fsAdapter: adapter, vaultContext: "test" });
+    await service.initialize();
+    const result2 = await service.initialize();
+    expect(result2.contractCreated).toBe(false);
+    expect(result2.overviewCreated).toBe(false);
+  });
+
+  it("handles write failure gracefully — returns false without throwing", async () => {
+    const { adapter } = await makeTempVault();
+    const brokenAdapter = {
+      ...adapter,
+      exists: async () => false,
+      writeNote: async () => { throw new Error("EROFS: read-only file system"); },
+      listNotes: async () => [],
+      readNote: adapter.readNote.bind(adapter),
+      deleteNote: adapter.deleteNote.bind(adapter),
+      stat: adapter.stat.bind(adapter),
+    };
+    const service = new VaultAutoInitService({ fsAdapter: brokenAdapter, vaultContext: "test" });
+    const result = await service.initialize();
+    expect(result.contractCreated).toBe(false);
+    expect(result.overviewCreated).toBe(false);
+  });
+
+  it("no warning emitted when vault is empty (only meta files after init)", async () => {
+    const { adapter } = await makeTempVault();
+    const service = new VaultAutoInitService({ fsAdapter: adapter, vaultContext: "test" });
+    const result = await service.initialize();
+    expect(result.warnings).toEqual([]);
+  });
+});

--- a/src/use-cases/vault-auto-init.ts
+++ b/src/use-cases/vault-auto-init.ts
@@ -1,0 +1,62 @@
+import type { IFileSystemAdapter } from "../domain/interfaces/file-system-adapter.js";
+import { NoteAlreadyExistsError } from "../domain/errors/index.js";
+import { generateContractTemplate } from "./contract-template.js";
+import { generateOverviewStub } from "./overview-template.js";
+
+export interface AutoInitResult {
+  contractCreated: boolean;
+  overviewCreated: boolean;
+  warnings: string[];
+}
+
+export class VaultAutoInitService {
+  private readonly fsAdapter: IFileSystemAdapter;
+  private readonly vaultContext: string;
+
+  constructor(deps: { fsAdapter: IFileSystemAdapter; vaultContext: string }) {
+    this.fsAdapter = deps.fsAdapter;
+    this.vaultContext = deps.vaultContext;
+  }
+
+  async initialize(): Promise<AutoInitResult> {
+    const warnings: string[] = [];
+    let contractCreated = false;
+    let overviewCreated = false;
+
+    contractCreated = await this.createIfMissing(
+      "meta/contract.md",
+      () => generateContractTemplate(this.vaultContext, new Date().toISOString()),
+    );
+
+    if (contractCreated) {
+      const existingNotes = await this.fsAdapter.listNotes();
+      const hasOtherNotes = existingNotes.some((p) => p !== "meta/contract.md" && p !== "meta/overview.md");
+      if (hasOtherNotes) {
+        warnings.push(
+          "meta/contract.md auto-created in non-empty vault — review and customize for accurate scope and conventions",
+        );
+      }
+    }
+
+    overviewCreated = await this.createIfMissing(
+      "meta/overview.md",
+      () => generateOverviewStub(new Date().toISOString()),
+    );
+
+    return { contractCreated, overviewCreated, warnings };
+  }
+
+  private async createIfMissing(path: string, contentFn: () => string): Promise<boolean> {
+    try {
+      const exists = await this.fsAdapter.exists(path);
+      if (exists) return false;
+      await this.fsAdapter.writeNote(path, contentFn());
+      return true;
+    } catch (err) {
+      if (err instanceof NoteAlreadyExistsError) return false;
+      // Write failure (e.g. read-only filesystem) — degrade gracefully
+      console.error(`[vault-auto-init] Failed to create ${path}:`, err);
+      return false;
+    }
+  }
+}

--- a/src/use-cases/vault-resource-overview.test.ts
+++ b/src/use-cases/vault-resource-overview.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm, realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalFileSystemAdapter } from "../infrastructure/local-fs-adapter.js";
+import type { IEmbeddingProvider } from "../domain/interfaces/embedding-provider.js";
+import { VaultStatsComposer } from "./vault-stats.js";
+import { VaultOverviewResourceComposer } from "./vault-resource-overview.js";
+
+const tmpDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tmpDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function makeTempVault() {
+  const tmpPath = await mkdtemp(join(tmpdir(), "vault-resource-overview-test-"));
+  const vaultPath = await realpath(tmpPath);
+  tmpDirs.push(vaultPath);
+  const adapter = await LocalFileSystemAdapter.create(vaultPath);
+  return { adapter };
+}
+
+function fakeEmbedder(): IEmbeddingProvider {
+  return {
+    modelName: "test-model",
+    embed: async () => [0, 0, 0],
+    embedBatch: async (texts) => texts.map(() => [0, 0, 0]),
+    dimensions: 3,
+  };
+}
+
+function makeComposer(adapter: LocalFileSystemAdapter, vaultScope = "test vault") {
+  const statsComposer = new VaultStatsComposer({ fsAdapter: adapter, embedder: fakeEmbedder() });
+  return new VaultOverviewResourceComposer({ fsAdapter: adapter, statsComposer, vaultScope });
+}
+
+describe("VaultOverviewResourceComposer", () => {
+  it("starts with vault header using vaultScope", async () => {
+    const { adapter } = await makeTempVault();
+    const composer = makeComposer(adapter, "my research vault");
+    const result = await composer.compose();
+    expect(result).toMatch(/^# Vault: my research vault/);
+  });
+
+  it("includes Quick Stats section", async () => {
+    const { adapter } = await makeTempVault();
+    const composer = makeComposer(adapter);
+    const result = await composer.compose();
+    expect(result).toContain("## Quick Stats");
+    expect(result).toContain("**Files**:");
+    expect(result).toContain("**Index status**:");
+  });
+
+  it("includes contract.md content when present", async () => {
+    const { adapter } = await makeTempVault();
+    await adapter.writeNote("meta/contract.md", "# Vault Navigation Contract\n\n## Scope\n\nMy scope");
+    const composer = makeComposer(adapter);
+    const result = await composer.compose();
+    expect(result).toContain("# Vault Navigation Contract");
+    expect(result).toContain("My scope");
+  });
+
+  it("omits contract section when contract.md missing", async () => {
+    const { adapter } = await makeTempVault();
+    const composer = makeComposer(adapter);
+    const result = await composer.compose();
+    expect(result).not.toContain("Vault Navigation Contract");
+  });
+
+  it("includes overview.md body when present and non-empty", async () => {
+    const { adapter } = await makeTempVault();
+    await adapter.writeNote("meta/overview.md", "---\nschema_version: 1\n---\n\n# Vault Overview\n\nActual content here.");
+    const composer = makeComposer(adapter);
+    const result = await composer.compose();
+    expect(result).toContain("Actual content here.");
+  });
+
+  it("omits overview section when overview.md missing", async () => {
+    const { adapter } = await makeTempVault();
+    const composer = makeComposer(adapter);
+    const result = await composer.compose();
+    expect(result.split("\n\n").length).toBeLessThanOrEqual(3);
+  });
+
+  it("omits overview section when overview.md body is only frontmatter and comments", async () => {
+    const { adapter } = await makeTempVault();
+    await adapter.writeNote(
+      "meta/overview.md",
+      "---\nschema_version: 1\nmanaged_by: user\n---\n\n<!-- Leave empty if you don't want to maintain it. -->",
+    );
+    const composer = makeComposer(adapter);
+    const result = await composer.compose();
+    expect(result).not.toContain("Leave empty");
+  });
+
+  it("sanitizes special characters in vaultScope in header", async () => {
+    const { adapter } = await makeTempVault();
+    const composer = makeComposer(adapter, "vault [notes] with `backticks`");
+    const result = await composer.compose();
+    expect(result).toContain("vault \\[notes\\] with \\`backticks\\`");
+  });
+
+  it("composes all 4 sections when all files present and overview has content", async () => {
+    const { adapter } = await makeTempVault();
+    await adapter.writeNote("meta/contract.md", "# Contract\n\n## Scope\n\nMy scope");
+    await adapter.writeNote("meta/overview.md", "---\nschema_version: 1\n---\n\n# Overview\n\nSome content.");
+    const composer = makeComposer(adapter, "full vault");
+    const result = await composer.compose();
+    expect(result).toContain("# Vault: full vault");
+    expect(result).toContain("## Quick Stats");
+    expect(result).toContain("# Contract");
+    expect(result).toContain("Some content.");
+  });
+});

--- a/src/use-cases/vault-resource-overview.ts
+++ b/src/use-cases/vault-resource-overview.ts
@@ -1,0 +1,83 @@
+import type { IFileSystemAdapter } from "../domain/interfaces/file-system-adapter.js";
+import { NoteNotFoundError } from "../domain/errors/index.js";
+import type { VaultStatsComposer } from "./vault-stats.js";
+import { sanitizeForMarkdown } from "./markdown-utils.js";
+
+function stripFrontmatterAndComments(content: string): string {
+  let body = content;
+  if (body.startsWith("---")) {
+    const end = body.indexOf("\n---", 3);
+    if (end !== -1) {
+      body = body.slice(end + 4);
+    }
+  }
+  body = body.replace(/<!--[\s\S]*?-->/g, "");
+  return body.trim();
+}
+
+function formatStats(stats: Awaited<ReturnType<VaultStatsComposer["computeStats"]>>): string {
+  const lines: string[] = [
+    `## Quick Stats`,
+    ``,
+    `- **Files**: ${stats.fileCount}`,
+    `- **Index status**: ${stats.indexStatus}`,
+    `- **Embedding provider**: ${stats.embeddingProvider}`,
+  ];
+
+  if (stats.topDirectories.length > 0) {
+    lines.push(`- **Top directories**:`);
+    for (const dir of stats.topDirectories) {
+      lines.push(`  - \`${dir.name}/\` (${dir.fileCount} files)`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export class VaultOverviewResourceComposer {
+  private readonly fsAdapter: IFileSystemAdapter;
+  private readonly statsComposer: VaultStatsComposer;
+  private readonly vaultScope: string;
+
+  constructor(deps: {
+    fsAdapter: IFileSystemAdapter;
+    statsComposer: VaultStatsComposer;
+    vaultScope: string;
+  }) {
+    this.fsAdapter = deps.fsAdapter;
+    this.statsComposer = deps.statsComposer;
+    this.vaultScope = deps.vaultScope;
+  }
+
+  async compose(): Promise<string> {
+    const safeScope = sanitizeForMarkdown(this.vaultScope);
+    const sections: string[] = [`# Vault: ${safeScope}`];
+
+    const stats = await this.statsComposer.computeStats();
+    sections.push(formatStats(stats));
+
+    const contractContent = await this.readFileSafe("meta/contract.md");
+    if (contractContent !== null) {
+      sections.push(contractContent);
+    }
+
+    const overviewContent = await this.readFileSafe("meta/overview.md");
+    if (overviewContent !== null) {
+      const body = stripFrontmatterAndComments(overviewContent);
+      if (body) {
+        sections.push(body);
+      }
+    }
+
+    return sections.join("\n\n");
+  }
+
+  private async readFileSafe(path: string): Promise<string | null> {
+    try {
+      return await this.fsAdapter.readNote(path);
+    } catch (err) {
+      if (err instanceof NoteNotFoundError) return null;
+      throw err;
+    }
+  }
+}

--- a/src/use-cases/vault-stats.test.ts
+++ b/src/use-cases/vault-stats.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm, realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalFileSystemAdapter } from "../infrastructure/local-fs-adapter.js";
+import type { IEmbeddingProvider } from "../domain/interfaces/embedding-provider.js";
+import type { VaultIndexer, IndexingHealthStatus } from "./vault-indexer.js";
+import { VaultStatsComposer } from "./vault-stats.js";
+
+const tmpDirs: string[] = [];
+
+afterEach(async () => {
+  for (const dir of tmpDirs.splice(0)) {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function makeTempVault() {
+  const tmpPath = await mkdtemp(join(tmpdir(), "vault-stats-test-"));
+  const vaultPath = await realpath(tmpPath);
+  tmpDirs.push(vaultPath);
+  const adapter = await LocalFileSystemAdapter.create(vaultPath);
+  return { adapter };
+}
+
+function fakeEmbedder(modelName = "test-model"): IEmbeddingProvider {
+  return {
+    modelName,
+    embed: async () => [0, 0, 0],
+    embedBatch: async (texts) => texts.map(() => [0, 0, 0]),
+    dimensions: 3,
+  };
+}
+
+function fakeIndexer(state: IndexingHealthStatus["indexingState"]): VaultIndexer {
+  return {
+    getHealthStatus: async () => ({
+      indexingState: state,
+      watcherState: "stopped",
+      queueDepth: 0,
+      failureCount: 0,
+      lastFailure: null,
+      indexedDocuments: 5,
+    }),
+  } as unknown as VaultIndexer;
+}
+
+describe("VaultStatsComposer", () => {
+  it("returns fileCount 0 for empty vault", async () => {
+    const { adapter } = await makeTempVault();
+    const composer = new VaultStatsComposer({ fsAdapter: adapter, embedder: fakeEmbedder() });
+    const stats = await composer.computeStats();
+    expect(stats.fileCount).toBe(0);
+    expect(stats.topDirectories).toEqual([]);
+  });
+
+  it("counts files in root (no directory)", async () => {
+    const { adapter } = await makeTempVault();
+    await adapter.writeNote("note1.md", "# Note 1");
+    await adapter.writeNote("note2.md", "# Note 2");
+    const composer = new VaultStatsComposer({ fsAdapter: adapter, embedder: fakeEmbedder() });
+    const stats = await composer.computeStats();
+    expect(stats.fileCount).toBe(2);
+    expect(stats.topDirectories).toEqual([]);
+  });
+
+  it("groups files by top-level directory", async () => {
+    const { adapter } = await makeTempVault();
+    await adapter.writeNote("notes/a.md", "a");
+    await adapter.writeNote("notes/b.md", "b");
+    await adapter.writeNote("projects/c.md", "c");
+    const composer = new VaultStatsComposer({ fsAdapter: adapter, embedder: fakeEmbedder() });
+    const stats = await composer.computeStats();
+    expect(stats.fileCount).toBe(3);
+    const notesDir = stats.topDirectories.find((d) => d.name === "notes");
+    const projectsDir = stats.topDirectories.find((d) => d.name === "projects");
+    expect(notesDir?.fileCount).toBe(2);
+    expect(projectsDir?.fileCount).toBe(1);
+  });
+
+  it("excludes meta/ directory from fileCount and topDirectories", async () => {
+    const { adapter } = await makeTempVault();
+    await adapter.writeNote("notes/a.md", "a");
+    await adapter.writeNote("meta/contract.md", "contract");
+    const composer = new VaultStatsComposer({ fsAdapter: adapter, embedder: fakeEmbedder() });
+    const stats = await composer.computeStats();
+    expect(stats.fileCount).toBe(1);
+    expect(stats.topDirectories.find((d) => d.name === "meta")).toBeUndefined();
+  });
+
+  it("limits topDirectories to max 10 entries sorted by count descending", async () => {
+    const { adapter } = await makeTempVault();
+    for (let i = 0; i < 12; i++) {
+      await adapter.writeNote(`dir${i}/file.md`, "x");
+    }
+    await adapter.writeNote("dir0/extra.md", "x");
+    const composer = new VaultStatsComposer({ fsAdapter: adapter, embedder: fakeEmbedder() });
+    const stats = await composer.computeStats();
+    expect(stats.topDirectories.length).toBeLessThanOrEqual(10);
+    expect(stats.topDirectories[0]?.name).toBe("dir0");
+    expect(stats.topDirectories[0]?.fileCount).toBe(2);
+  });
+
+  it("returns indexStatus 'not started' when no indexer provided", async () => {
+    const { adapter } = await makeTempVault();
+    const composer = new VaultStatsComposer({ fsAdapter: adapter, embedder: fakeEmbedder() });
+    const stats = await composer.computeStats();
+    expect(stats.indexStatus).toBe("not started");
+  });
+
+  it("returns indexStatus 'ready' when indexer is idle", async () => {
+    const { adapter } = await makeTempVault();
+    const composer = new VaultStatsComposer({
+      fsAdapter: adapter,
+      indexer: fakeIndexer("idle"),
+      embedder: fakeEmbedder(),
+    });
+    const stats = await composer.computeStats();
+    expect(stats.indexStatus).toBe("ready");
+  });
+
+  it("returns indexStatus 'building' when indexer is indexing", async () => {
+    const { adapter } = await makeTempVault();
+    const composer = new VaultStatsComposer({
+      fsAdapter: adapter,
+      indexer: fakeIndexer("indexing"),
+      embedder: fakeEmbedder(),
+    });
+    const stats = await composer.computeStats();
+    expect(stats.indexStatus).toBe("building");
+  });
+
+  it("reflects embedder modelName in embeddingProvider field", async () => {
+    const { adapter } = await makeTempVault();
+    const composer = new VaultStatsComposer({
+      fsAdapter: adapter,
+      embedder: fakeEmbedder("ollama/nomic-embed-text"),
+    });
+    const stats = await composer.computeStats();
+    expect(stats.embeddingProvider).toBe("ollama/nomic-embed-text");
+  });
+});

--- a/src/use-cases/vault-stats.ts
+++ b/src/use-cases/vault-stats.ts
@@ -1,0 +1,62 @@
+import type { IFileSystemAdapter } from "../domain/interfaces/file-system-adapter.js";
+import type { IEmbeddingProvider } from "../domain/interfaces/embedding-provider.js";
+import type { VaultIndexer } from "./vault-indexer.js";
+
+export interface VaultStats {
+  fileCount: number;
+  topDirectories: Array<{ name: string; fileCount: number }>;
+  indexStatus: "ready" | "building" | "not started";
+  embeddingProvider: string;
+}
+
+export class VaultStatsComposer {
+  private readonly fsAdapter: IFileSystemAdapter;
+  private readonly indexer: VaultIndexer | undefined;
+  private readonly embedder: IEmbeddingProvider;
+
+  constructor(deps: {
+    fsAdapter: IFileSystemAdapter;
+    indexer?: VaultIndexer;
+    embedder: IEmbeddingProvider;
+  }) {
+    this.fsAdapter = deps.fsAdapter;
+    this.indexer = deps.indexer;
+    this.embedder = deps.embedder;
+  }
+
+  async computeStats(): Promise<VaultStats> {
+    const allNotes = await this.fsAdapter.listNotes();
+    const nonMetaNotes = allNotes.filter((p) => !p.startsWith("meta/"));
+
+    const dirCounts = new Map<string, number>();
+    for (const notePath of nonMetaNotes) {
+      const slashIdx = notePath.indexOf("/");
+      if (slashIdx > 0) {
+        const dir = notePath.slice(0, slashIdx);
+        dirCounts.set(dir, (dirCounts.get(dir) ?? 0) + 1);
+      }
+    }
+
+    const topDirectories = [...dirCounts.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)
+      .map(([name, fileCount]) => ({ name, fileCount }));
+
+    let indexStatus: VaultStats["indexStatus"] = "not started";
+    if (this.indexer) {
+      const health = await this.indexer.getHealthStatus();
+      if (health.indexingState === "indexing") {
+        indexStatus = "building";
+      } else {
+        indexStatus = "ready";
+      }
+    }
+
+    return {
+      fileCount: nonMetaNotes.length,
+      topDirectories,
+      indexStatus,
+      embeddingProvider: this.embedder.modelName,
+    };
+  }
+}


### PR DESCRIPTION
Introduce auto-derived vault context so agents can infer vault scope, relevance, and available actions without any user configuration beyond VAULT_PATH. Power users retain full control via VAULT_CONTEXT env var, meta/contract.md, and meta/overview.md.

Core changes:

- Auto-derive vault summary from directory structure, note count, and frontmatter keys when VAULT_CONTEXT is unset or generic
- Deterministic resolution order: explicit VAULT_CONTEXT → auto-derived summary → generic fallback
- First-view priming on initial view call with vault_orientation metadata (scope, top directories, index status, hints)
- Fix priming response shape to safely handle array, string, and object action results without corruption
- Read package version at startup instead of hardcoded 0.1.0
- Map vault indexer states explicitly (ready/building/not_started/error) instead of collapsing non-indexing to ready
- Auto-init meta/contract.md and meta/overview.md with starter templates on first run (never overwrites)
- Compose vault://overview, vault://contract, vault://stats resources on-demand from live vault state
- Fix log level semantics: info/warn no longer flow through logger.error

New modules:
- vault-context-summary: cheap auto-derived vault description
- vault-stats: index health, note count, directory listing
- vault-resource-overview: live resource composition
- vault-auto-init: idempotent meta/ file creation
- contract-template / overview-template: starter content
- instructions-composer: dynamic MCP instructions
- markdown-utils: sanitizeForMarkdown helper

README rewritten to position VAULT_CONTEXT as optional enhancement, document zero-config → power-user progression, and clarify the three-layer context model (auto-derived / env var / meta files).

198 new tests across 10 test files. 516 total tests passing.