### PR TITLE
fix: refresh auto overview and vault scope after indexing changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,14 @@
 
 `npm install` and point it at a folder. Hybrid search, AST editing, zero-config embeddings. No app, no plugins, no API keys.
 
-<!-- Note: Badge URLs reference the current GitHub repo (Wirux/mcp-obsidian). -->
-<!-- Update these if/when the repo is renamed to mcp-markdown-vault. -->
-[![CI / Release](https://github.com/Wirux/mcp-obsidian/actions/workflows/release.yml/badge.svg)](https://github.com/Wirux/mcp-obsidian/actions/workflows/release.yml)
-[![PR Check](https://github.com/Wirux/mcp-obsidian/actions/workflows/pr-check.yml/badge.svg)](https://github.com/Wirux/mcp-obsidian/actions/workflows/pr-check.yml)
+[![CI / Release](https://github.com/wirux/mcp-markdown-vault/actions/workflows/release.yml/badge.svg)](https://github.com/wirux/mcp-markdown-vault/actions/workflows/release.yml)
+[![PR Check](https://github.com/wirux/mcp-markdown-vault/actions/workflows/pr-check.yml/badge.svg)](https://github.com/wirux/mcp-markdown-vault/actions/workflows/pr-check.yml)
 [![npm version](https://img.shields.io/npm/v/@wirux/mcp-markdown-vault?color=cb3837&logo=npm)](https://www.npmjs.com/package/@wirux/mcp-markdown-vault)
-[![Docker](https://img.shields.io/badge/ghcr.io-mcp--markdown--vault-blue?logo=docker)](https://github.com/Wirux/mcp-obsidian/pkgs/container/mcp-markdown-vault)
+[![Docker](https://img.shields.io/badge/ghcr.io-mcp--markdown--vault-blue?logo=docker)](https://github.com/wirux/mcp-markdown-vault/pkgs/container/mcp-markdown-vault)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Node.js](https://img.shields.io/badge/Node.js-%3E%3D22-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
-[![Tests](https://img.shields.io/badge/tests-516%20passed-brightgreen?logo=vitest&logoColor=white)](#-testing)
+[![Tests](https://img.shields.io/badge/tests-568%20passed-brightgreen?logo=vitest&logoColor=white)](#-testing)
 [![mcp-markdown-vault MCP server](https://glama.ai/mcp/servers/wirux/mcp-markdown-vault/badges/score.svg)](https://glama.ai/mcp/servers/wirux/mcp-markdown-vault)
 
 </div>
@@ -78,7 +76,7 @@
 | Tool | Actions | Description |
 |---|---|---|
 | 📁 **vault** | `list` `read` `create` `update` `delete` `stat` `create_from_template` | Full CRUD for vault notes + template scaffolding |
-| ✏️ **edit** | `append` `prepend` `replace` `line_replace` `string_replace` `frontmatter_set` `batch` | AST-based patching + freeform fallback + frontmatter update + batch edit (supports `dryRun` diff preview) |
+| ✏️ **edit** | `append` `prepend` `replace` `line_replace` `string_replace` `frontmatter_set` + `operations[]` batch mode | AST-based patching + freeform fallback + frontmatter update + batch edit (supports `dryRun` diff preview) |
 | 👁️ **view** | `search` `global_search` `semantic_search` `outline` `read` `frontmatter_get` `bulk_read` `backlinks` | Fragment retrieval, cross-vault search, hybrid semantic search, read by heading, frontmatter read, bulk read, backlinks |
 | 🔄 **workflow** | `status` `transition` `history` `reset` | Petri net state machine control |
 | ⚙️ **system** | `status` `reindex` `overview` | Server health, indexing info, vault structure overview |
@@ -147,8 +145,8 @@ Edit `docker-compose.yml` to point at your markdown vault directory. The default
 ### 🛠️ Development (from source)
 
 ```bash
-git clone https://github.com/Wirux/mcp-obsidian.git
-cd mcp-obsidian
+git clone https://github.com/wirux/mcp-markdown-vault.git
+cd mcp-markdown-vault
 npm install
 npm run build
 VAULT_PATH=/path/to/your/vault node dist/index.js
@@ -195,14 +193,19 @@ The server selects an embedding provider automatically:
 | Variable | Default | Description |
 |---|---|---|
 | `VAULT_PATH` | `/vault` | Markdown vault directory |
-| `VAULT_CONTEXT_MODE` | `auto` | Vault orientation mode: `auto` (server generates `meta/overview.md` from structural heuristics) or `manual` (you author `meta/overview.md` yourself) |
+| `VAULT_CONTEXT_MODE` | `auto` | Vault orientation mode: `auto` (server generates and refreshes `meta/overview.md`, including the `vault_scope` frontmatter) or `manual` (you author `meta/overview.md` yourself) |
+| `VAULT_CONTEXT` | *(deprecated)* | Deprecated and ignored. Use `VAULT_CONTEXT_MODE` instead. |
 | `MCP_TRANSPORT_TYPE` | `stdio` | `stdio` (single client) or `sse` (multi-client HTTP) |
 | `PORT` | `3000` | HTTP port (SSE mode only) |
 | `OLLAMA_URL` | *(unset)* | Set to enable Ollama embeddings |
 | `OLLAMA_MODEL` | `nomic-embed-text` | Ollama embedding model name |
 | `OLLAMA_DIMENSIONS` | `768` | Ollama embedding vector dimensions |
 | `VECTOR_STORE_URL` | *(unset)* | Set to use Qdrant (e.g. `http://localhost:6333`). If unset, local persisted flat store is used. |
+| `VECTOR_STORE_COLLECTION` | `markdown_vault` | Qdrant collection name when `VECTOR_STORE_URL` is set. |
 | `VECTOR_STORE_RESET` | `false` | Set to `true` to auto-delete a mismatched vector index on startup and rebuild from scratch. |
+| `MCP_AUTH_TOKEN` | *(unset)* | Bearer token for SSE transport auth. If set, all SSE endpoints require `Authorization: Bearer <token>`. |
+| `HOST_BIND_ADDRESS` | `127.0.0.1` | Bind address for the SSE HTTP server. |
+| `BODY_LIMIT_BYTES` | `1mb` | Max JSON request body size for SSE `POST /messages`. |
 
 > **Note**: When using the default local vector store, a `.markdown_vault_mcp` directory will be created in your vault. It's recommended to add this directory to your `.gitignore`.
 
@@ -230,9 +233,9 @@ When an MCP client connects, the server automatically provides vault context so 
 
 ### Making agents find your vault
 
-In `auto` mode (the default), the server generates `meta/overview.md` automatically after startup using structural heuristics: top directories, file counts, tag frequency, and H1 headings from top files. No configuration needed.
+In `auto` mode (the default), the server generates `meta/overview.md` automatically after startup using structural heuristics: top directories, file counts, tag frequency, and H1 headings. It also writes a one-line `vault_scope` field in the frontmatter, which is the host-visible description used for MCP handshake instructions, tool descriptions, and first-call priming.
 
-In `manual` mode, you author `meta/overview.md` yourself. Set `VAULT_CONTEXT_MODE=manual` and write whatever helps an agent understand your vault:
+In `manual` mode, you author `meta/overview.md` yourself. Set `VAULT_CONTEXT_MODE=manual`, edit the `vault_scope` frontmatter for the one-line host-visible description, and use the markdown body for richer narrative context:
 
 ```json
 {
@@ -248,7 +251,7 @@ In `manual` mode, you author `meta/overview.md` yourself. Set `VAULT_CONTEXT_MOD
 }
 ```
 
-In both modes, `meta/overview.md` is the canonical source of vault description for connected agents.
+In both modes, `meta/overview.md` is the canonical source of vault description for connected agents: `vault_scope` in frontmatter supplies the short description, and the markdown body feeds the richer `vault://overview` resource.
 
 ### How context is delivered
 
@@ -256,16 +259,16 @@ The server uses four complementary mechanisms so behavior degrades gracefully ac
 
 | Mechanism | When | What the agent sees |
 |---|---|---|
-| **`instructions` field** | MCP handshake (session start) | Vault scope + tool dispatcher summary. Supported by Claude Desktop, Claude Code, Cursor. |
+| **`instructions` field** | MCP handshake (session start) | The current `vault_scope` + tool dispatcher summary. Supported by Claude Desktop, Claude Code, Cursor. |
 | **MCP Resources** | On-demand via `ReadResource` | `vault://overview` (composed view with live stats, overview, and conventions), `vault://stats` (live JSON) |
-| **First-call priming** | First `view` tool call per session | `_meta.vault_orientation` block with scope + hint to read `vault://overview` |
-| **`view` tool description** | Tool listing | Includes the vault scope string from `meta/overview.md` for tool-selection matching |
+| **First-call priming** | First `view` tool call per session | `_meta.vault_orientation` block with the current `vault_scope` + hint to read `vault://overview` |
+| **`view` tool description** | Tool listing | Includes the current `vault_scope` string for tool-selection matching |
 
 Even if a client supports none of these (rare), the agent still discovers vault content through normal tool use.
 
 ### Two files: contract vs overview
 
-On first startup, the server creates two files in `<VAULT_PATH>/meta/`. In `manual` mode, both are created once and **never overwritten** — they are fully yours to edit. In `auto` mode, `meta/overview.md` is regenerated automatically after indexing completes and after every 5 meaningful file changes; `meta/contract.md` is still created once and never overwritten.
+On first startup, the server creates two files in `<VAULT_PATH>/meta/`. In `manual` mode, both are created once and **never overwritten** — they are fully yours to edit. In `auto` mode, `meta/overview.md` is regenerated automatically after indexing completes and after every 5 meaningful file changes; its `vault_scope` frontmatter is refreshed at the same time. `meta/contract.md` is still created once and never overwritten.
 
 #### `meta/contract.md` — Tool optimization (power users)
 
@@ -281,22 +284,24 @@ Tells agents **how** to use the vault's tools efficiently. Pre-filled with sensi
 
 Most users don't need to edit this. Power users can customize it to match their vault's specific conventions — agents read it as part of the `vault://overview` resource.
 
-> **Tip:** Add a `## Scope` section for a richer, multi-line vault description. Agents see it when reading the `vault://overview` resource.
+> **Tip:** Keep `vault_scope` short and specific — it is the one-line summary exposed to MCP hosts. Put richer, multi-line context in the body of `meta/overview.md`.
 
 #### `meta/overview.md` — Vault description (read-side)
 
-In `auto` mode: auto-generated after startup and refreshed after every 5 meaningful file changes. Contains top directories, file counts, tag frequency, and H1 headings from top files.
+In `auto` mode: auto-generated after startup and refreshed after every 5 meaningful file changes. The frontmatter contains `vault_scope`, a generated one-line summary capped to a fixed maximum length for host-visible context. The body contains top directories, file counts, tag frequency, and recent note titles.
 
-In `manual` mode: created as an empty stub. Write here whatever helps an agent understand your vault's content: active projects, key topic areas, organizational philosophy.
+In `manual` mode: created as an editable stub. Set `vault_scope` in frontmatter to control the one-line host-visible description, then write whatever helps an agent understand your vault's content in the body: active projects, key topic areas, organizational philosophy.
 
-Its content is the primary source for the `vault://overview` resource that agents read on demand.
+Its frontmatter `vault_scope` is the primary source for handshake-visible one-line context, and its body is the primary source for the `vault://overview` resource that agents read on demand.
 
 ### Hot reload behavior
 
 | What changed | Effect | Restart needed? |
 |---|---|---|
 | `meta/contract.md` | Reflected in `vault://overview` on next read | No |
-| `meta/overview.md` | Reflected in `vault://overview` on next read | No |
+| `meta/overview.md` body | Reflected in `vault://overview` on next read | No |
+| Auto-generated `vault_scope` refresh | Picked up automatically when auto mode rewrites `meta/overview.md` | No |
+| Manual edits to `vault_scope` | Reflected in `vault://overview` on next read; restart/reconnect to guarantee new handshake-visible scope | Usually yes |
 | `VAULT_CONTEXT_MODE` env var | Changes auto vs manual behavior | Yes |
 
 ### Migration notes
@@ -319,13 +324,13 @@ Fully automated via GitHub Actions and [Semantic Release](https://semantic-relea
 - Versioning follows [Conventional Commits](https://www.conventionalcommits.org/) — `feat:` = minor, `fix:` = patch, `feat!:` / `BREAKING CHANGE:` = major
 - Docker images are built for `linux/amd64` and `linux/arm64` via QEMU
 - NPM package published as [`@wirux/mcp-markdown-vault`](https://www.npmjs.com/package/@wirux/mcp-markdown-vault)
-- Docker image available at [`ghcr.io/wirux/mcp-markdown-vault`](https://github.com/Wirux/mcp-obsidian/pkgs/container/mcp-markdown-vault)
+- Docker image available at [`ghcr.io/wirux/mcp-markdown-vault`](https://github.com/wirux/mcp-markdown-vault/pkgs/container/mcp-markdown-vault)
 
 ---
 
 ## 🧪 Testing
 
-**516 tests** across 46 files, written test-first (TDD).
+**568 tests** across 49 files, written test-first (TDD).
 
 ```bash
 npm test                                          # Run all tests

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -122,7 +122,7 @@ describe("src/index composition root helpers", () => {
     expect(await fsAdapter.readNote("meta/overview.md")).toBe("# Custom Overview");
   });
 
-  it("auto-init failure still returns instructions and starts composition flow", async () => {
+  it("auto-init failure still returns scope provider and starts composition flow", async () => {
     const { fsAdapter } = await makeTempVault();
     const errors: unknown[][] = [];
     const brokenFsAdapter: IFileSystemAdapter = {
@@ -146,8 +146,8 @@ describe("src/index composition root helpers", () => {
       },
     });
 
-    expect(result.instructions.length).toBeGreaterThan(0);
     expect(typeof result.getVaultScope()).toBe("string");
+    expect(result.scopeProvider.getScope()).toBe(result.getVaultScope());
     expect(errors).toEqual([]);
   });
 
@@ -163,21 +163,21 @@ describe("src/index composition root helpers", () => {
       vectorStore: new InMemoryVectorStore(),
       embedder: new FakeEmbedder(),
       vaultRoot: vaultPath,
-      instructions: orientation.instructions,
       getVaultScope: orientation.getVaultScope,
     });
 
     const instructions = await readInitializeInstructions(serverFactory());
 
-    expect(orientation.instructions.length).toBeGreaterThan(0);
-    expect(instructions).toBe(orientation.instructions);
+    expect(instructions).toBeDefined();
+    expect(instructions!.length).toBeGreaterThan(0);
+    expect(instructions).toContain("Vault scope:");
   });
 
   it("getVaultScope returns default when overview.md does not exist", async () => {
     const { fsAdapter } = await makeTempVault();
-    const getVaultScope = makeVaultScopeProvider(fsAdapter);
+    const provider = makeVaultScopeProvider(fsAdapter);
     await new Promise((resolve) => setTimeout(resolve, 50));
-    expect(getVaultScope()).toBe(DEFAULT_VAULT_SCOPE);
+    expect(provider.getScope()).toBe(DEFAULT_VAULT_SCOPE);
   });
 
   it("createServerFactory injects workflow per server instance while preserving orientation data", async () => {
@@ -193,7 +193,6 @@ describe("src/index composition root helpers", () => {
       vectorStore,
       embedder: new FakeEmbedder(),
       vaultRoot: vaultPath,
-      instructions: orientation.instructions,
       getVaultScope: orientation.getVaultScope,
     });
 
@@ -236,5 +235,128 @@ describe("parseVaultContextConfig integration", () => {
     const { parseVaultContextConfig } = await import("./use-cases/vault-context-config.js");
     const config = parseVaultContextConfig({ VAULT_CONTEXT: "old value" });
     expect(config.deprecatedVaultContext).toBe("old value");
+  });
+});
+
+describe("vault scope from frontmatter integration", () => {
+  it("makeVaultScopeProvider reads vault_scope from frontmatter", async () => {
+    const { fsAdapter } = await makeTempVault();
+    await fsAdapter.writeNote(
+      "meta/overview.md",
+      `---\nschema_version: 1\nvault_scope: "my custom vault scope"\n---\n\n# Overview\n`,
+    );
+
+    const provider = makeVaultScopeProvider(fsAdapter);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(provider.getScope()).toBe("my custom vault scope");
+  });
+
+  it("makeVaultScopeProvider falls back to DEFAULT_VAULT_SCOPE when vault_scope missing", async () => {
+    const { fsAdapter } = await makeTempVault();
+    await fsAdapter.writeNote(
+      "meta/overview.md",
+      `---\nschema_version: 1\nmanaged_by: auto\n---\n\n# Overview\n`,
+    );
+
+    const provider = makeVaultScopeProvider(fsAdapter);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(provider.getScope()).toBe(DEFAULT_VAULT_SCOPE);
+  });
+
+  it("makeVaultScopeProvider.refresh() picks up new vault_scope after overview rewrite", async () => {
+    const { fsAdapter } = await makeTempVault();
+    await fsAdapter.writeNote(
+      "meta/overview.md",
+      `---\nvault_scope: "original scope"\n---\n\n# Overview\n`,
+    );
+
+    const provider = makeVaultScopeProvider(fsAdapter);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(provider.getScope()).toBe("original scope");
+
+    await fsAdapter.writeNote(
+      "meta/overview.md",
+      `---\nvault_scope: "updated scope after refresh"\n---\n\n# Overview\n`,
+      true,
+    );
+    provider.refresh();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(provider.getScope()).toBe("updated scope after refresh");
+  });
+
+  it("createServerFactory uses real vault scope in instructions on each server creation", async () => {
+    const { fsAdapter, vaultPath } = await makeTempVault();
+    await fsAdapter.writeNote(
+      "meta/overview.md",
+      `---\nvault_scope: "dynamic scope value"\n---\n\n# Overview\n`,
+    );
+
+    const provider = makeVaultScopeProvider(fsAdapter);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const serverFactory = createServerFactory({
+      fsAdapter,
+      vectorStore: new InMemoryVectorStore(),
+      embedder: new FakeEmbedder(),
+      vaultRoot: vaultPath,
+      getVaultScope: provider.getScope,
+    });
+
+    const instructions = await readInitializeInstructions(serverFactory());
+    expect(instructions).toContain("dynamic scope value");
+  });
+
+  it("after scope refresh, new server sees updated instructions", async () => {
+    const { fsAdapter, vaultPath } = await makeTempVault();
+    await fsAdapter.writeNote(
+      "meta/overview.md",
+      `---\nvault_scope: "scope v1"\n---\n\n# Overview\n`,
+    );
+
+    const provider = makeVaultScopeProvider(fsAdapter);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const serverFactory = createServerFactory({
+      fsAdapter,
+      vectorStore: new InMemoryVectorStore(),
+      embedder: new FakeEmbedder(),
+      vaultRoot: vaultPath,
+      getVaultScope: provider.getScope,
+    });
+
+    const instructions1 = await readInitializeInstructions(serverFactory());
+    expect(instructions1).toContain("scope v1");
+
+    await fsAdapter.writeNote(
+      "meta/overview.md",
+      `---\nvault_scope: "scope v2"\n---\n\n# Overview\n`,
+      true,
+    );
+    provider.refresh();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const instructions2 = await readInitializeInstructions(serverFactory());
+    expect(instructions2).toContain("scope v2");
+    expect(instructions2).not.toContain("scope v1");
+  });
+
+  it("manual mode: user-authored overview with vault_scope is respected", async () => {
+    const { fsAdapter } = await makeTempVault();
+    await fsAdapter.writeNote(
+      "meta/overview.md",
+      `---\nschema_version: 1\nmanaged_by: user\nvault_scope: "user-written scope"\n---\n\n# My Vault\n`,
+    );
+
+    const orientation = await initializeVaultOrientation({
+      fsAdapter,
+      mode: "manual",
+      logger: { error: () => undefined },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(orientation.getVaultScope()).toBe("user-written scope");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,13 +31,19 @@ import {
   type VaultContextMode,
 } from "./use-cases/vault-context-config.js";
 import { OverviewManager } from "./use-cases/overview-manager.js";
+import { extractVaultScopeFromFrontmatter } from "./use-cases/vault-scope.js";
 
 export const DEFAULT_VAULT_SCOPE = "general markdown notes vault";
 
+export interface VaultScopeProvider {
+  getScope: () => string;
+  refresh: () => void;
+}
+
 export interface VaultOrientation {
   initResult: AutoInitResult;
+  scopeProvider: VaultScopeProvider;
   getVaultScope: () => string;
-  instructions: string;
 }
 
 export async function initializeVaultOrientation(deps: {
@@ -69,32 +75,28 @@ export async function initializeVaultOrientation(deps: {
     logger.error(`[warn] ${warning}`);
   }
 
-  const getVaultScope = makeVaultScopeProvider(deps.fsAdapter);
+  const scopeProvider = makeVaultScopeProvider(deps.fsAdapter);
 
   return {
     initResult,
-    getVaultScope,
-    instructions: composeInstructions(DEFAULT_VAULT_SCOPE),
+    scopeProvider,
+    getVaultScope: scopeProvider.getScope,
   };
 }
 
 export function makeVaultScopeProvider(
   fsAdapter: IFileSystemAdapter,
-): () => string {
+): VaultScopeProvider {
   let cached: string = DEFAULT_VAULT_SCOPE;
 
   const refresh = (): void => {
     fsAdapter.readNote("meta/overview.md").then((content) => {
-      const firstMeaningfulLine = content
-        .split("\n")
-        .map((l) => l.trim())
-        .find((l) => l.length > 0 && !l.startsWith("---") && !l.startsWith("#") && !l.startsWith("schema_version") && !l.startsWith("generated") && !l.startsWith("managed_by"));
-      cached = firstMeaningfulLine ?? DEFAULT_VAULT_SCOPE;
+      cached = extractVaultScopeFromFrontmatter(content) ?? DEFAULT_VAULT_SCOPE;
     }).catch(() => { cached = DEFAULT_VAULT_SCOPE; });
   };
 
   refresh();
-  return () => cached;
+  return { getScope: () => cached, refresh };
 }
 
 export function createServerFactory(
@@ -104,6 +106,9 @@ export function createServerFactory(
     createMcpServer({
       ...deps,
       workflow: new WorkflowStateMachine(),
+      instructions: composeInstructions(
+        (deps.getVaultScope ?? (() => DEFAULT_VAULT_SCOPE))(),
+      ),
     });
 }
 
@@ -171,7 +176,7 @@ async function main(): Promise<void> {
   const allowReset = process.env["VECTOR_STORE_RESET"] === "true";
 
   const fsAdapter = await LocalFileSystemAdapter.create(vaultRoot);
-  const { getVaultScope, instructions } = await initializeVaultOrientation({
+  const { scopeProvider, getVaultScope } = await initializeVaultOrientation({
     fsAdapter,
     mode: config.mode,
   });
@@ -219,7 +224,9 @@ async function main(): Promise<void> {
   if (config.mode === "auto") {
     overviewManager = new OverviewManager({ fsAdapter });
     indexer.addOnThresholdReached(() => {
-      overviewManager!.writeOverview().catch((err: unknown) =>
+      overviewManager!.writeOverview().then(() => {
+        scopeProvider.refresh();
+      }).catch((err: unknown) =>
         console.error("Overview refresh failed:", err),
       );
       indexer.resetChangeCount();
@@ -233,7 +240,6 @@ async function main(): Promise<void> {
     vaultRoot,
     backlinkIndex,
     indexer,
-    instructions,
     getVaultScope,
   });
 
@@ -253,6 +259,7 @@ async function main(): Promise<void> {
         await overviewManager.writeOverview().catch((err: unknown) =>
           console.error("Initial overview generation failed:", err),
         );
+        scopeProvider.refresh();
       }
     })
     .catch((err: unknown) =>

--- a/src/use-cases/overview-manager.test.ts
+++ b/src/use-cases/overview-manager.test.ts
@@ -117,6 +117,29 @@ describe("OverviewManager", () => {
     expect(written).toContain("- Written");
   });
 
+  it("overwrites existing meta/overview.md stub on subsequent writeOverview calls", async () => {
+    const { adapter } = await makeTempVault();
+    // Simulate auto-init creating the stub first
+    await adapter.writeNote(
+      "meta/overview.md",
+      "---\nschema_version: 1\nmanaged_by: auto\n---\n\n# Vault Overview\n\n<!-- stub -->\n",
+    );
+    // Add real content to the vault
+    await adapter.writeNote("docs/note.md", "---\ntags: testing\n---\n# My Note\n");
+
+    const manager = new OverviewManager({ fsAdapter: adapter });
+
+    // This must NOT throw NoteAlreadyExistsError — it must overwrite
+    await manager.writeOverview();
+
+    const content = await adapter.readNote("meta/overview.md");
+    expect(content).toContain("## Statistics");
+    expect(content).toContain("- **Total files**: 1");
+    expect(content).toContain("- `testing` (1)");
+    expect(content).toContain("- My Note");
+    expect(content).not.toContain("<!-- stub -->");
+  });
+
   it("shouldRefresh uses default threshold of five", () => {
     const manager = new OverviewManager({
       fsAdapter: {

--- a/src/use-cases/overview-manager.ts
+++ b/src/use-cases/overview-manager.ts
@@ -1,5 +1,6 @@
 import yaml from "js-yaml";
 import type { IFileSystemAdapter } from "../domain/interfaces/file-system-adapter.js";
+import { generateVaultScope } from "./vault-scope.js";
 
 interface DirectorySummary {
   name: string;
@@ -42,12 +43,19 @@ export class OverviewManager {
         .filter((directory): directory is string => directory !== undefined),
     ).size;
 
+    const vaultScope = generateVaultScope({
+      totalFiles: nonMetaNotePaths.length,
+      directories: topDirectories,
+      tags,
+    });
+
     return [
       "---",
       "schema_version: 1",
       "generated_by: mcp-markdown-vault",
       `generated_at: ${timestamp}`,
       "managed_by: auto",
+      `vault_scope: ${JSON.stringify(vaultScope)}`,
       "---",
       "",
       "# Vault Overview",

--- a/src/use-cases/overview-manager.ts
+++ b/src/use-cases/overview-manager.ts
@@ -74,7 +74,7 @@ export class OverviewManager {
 
   async writeOverview(): Promise<void> {
     const content = await this.generate();
-    await this.fsAdapter.writeNote("meta/overview.md", content);
+    await this.fsAdapter.writeNote("meta/overview.md", content, true);
   }
 
   shouldRefresh(changeCount: number): boolean {

--- a/src/use-cases/overview-template.ts
+++ b/src/use-cases/overview-template.ts
@@ -5,6 +5,7 @@ schema_version: 1
 generated_by: mcp-markdown-vault
 generated_at: ${timestamp}
 managed_by: auto
+vault_scope: "general markdown notes vault"
 ---
 
 # Vault Overview
@@ -18,12 +19,13 @@ schema_version: 1
 generated_by: mcp-markdown-vault
 generated_at: ${timestamp}
 managed_by: user
+vault_scope: "describe your vault contents here"
 ---
 
 # Vault Overview
 
 <!-- Free-form narrative about this vault's current contents and state.
      Fully user-controlled — the server never modifies this file after creation.
-     Leave empty if you don't want to maintain it manually. -->
+     Edit vault_scope above to set the one-line description shown to MCP hosts. -->
 `;
 }

--- a/src/use-cases/vault-indexer.test.ts
+++ b/src/use-cases/vault-indexer.test.ts
@@ -509,6 +509,132 @@ describe("VaultIndexer", () => {
 
       expect(await store.has("gone.md")).toBe(false);
     });
+
+    it("unlink does not increment failureCount or set lastFailure", async () => {
+      await fs.writeFile(
+        path.join(tmpDir, "delete-me.md"),
+        "# Delete\n\nContent.\n",
+      );
+      await indexer.indexFile("delete-me.md");
+
+      await indexer.startWatching({ debounceMs: 50 });
+
+      await fs.unlink(path.join(tmpDir, "delete-me.md"));
+      watcher.emit("unlink", path.join(tmpDir, "delete-me.md"));
+
+      await sleep(100);
+
+      expect(indexer.failureCount).toBe(0);
+      expect(indexer.lastFailureTime).toBeNull();
+      expect(indexer.lastFailureSource).toBeNull();
+
+      const status = await indexer.getHealthStatus();
+      expect(status.failureCount).toBe(0);
+      expect(status.lastFailure).toBeNull();
+    });
+
+    it("queued file deleted before drain does not set lastFailure", async () => {
+      await fs.writeFile(
+        path.join(tmpDir, "race.md"),
+        "# Race\n\nContent.\n",
+      );
+      await indexer.indexFile("race.md");
+
+      await indexer.startWatching({ debounceMs: 50 });
+
+      watcher.emit("change", path.join(tmpDir, "race.md"));
+      await fs.unlink(path.join(tmpDir, "race.md"));
+
+      await sleep(200);
+
+      expect(indexer.failureCount).toBe(0);
+      expect(indexer.lastFailureSource).toBeNull();
+      expect(await store.has("race.md")).toBe(false);
+    });
+
+    it("does not count a file disappearing between exists check and read as failure", async () => {
+      await fs.writeFile(
+        path.join(tmpDir, "toctou.md"),
+        "# TOCTOU\n\nContent.\n",
+      );
+      await indexer.indexFile("toctou.md");
+
+      const originalExists = fsAdapter.exists.bind(fsAdapter);
+      let deleteAfterExists = false;
+      fsAdapter.exists = async (notePath: string) => {
+        const exists = await originalExists(notePath);
+        if (notePath === "toctou.md" && exists && !deleteAfterExists) {
+          deleteAfterExists = true;
+          await fs.unlink(path.join(tmpDir, "toctou.md"));
+        }
+        return exists;
+      };
+
+      await indexer.startWatching({ debounceMs: 50 });
+      watcher.emit("change", path.join(tmpDir, "toctou.md"));
+
+      await sleep(200);
+
+      expect(indexer.failureCount).toBe(0);
+      expect(indexer.lastFailureTime).toBeNull();
+      expect(indexer.lastFailureSource).toBeNull();
+      expect(await store.has("toctou.md")).toBe(false);
+
+      const status = await indexer.getHealthStatus();
+      expect(status.failureCount).toBe(0);
+      expect(status.lastFailure).toBeNull();
+    });
+
+    it("genuine embed failure still increments failureCount and sets lastFailure", async () => {
+      const origEmbed = embedder.embed.bind(embedder);
+      embedder.embed = async (text: string) => {
+        if (text.includes("RealFail")) throw new Error("embedder crashed");
+        return origEmbed(text);
+      };
+
+      await indexer.startWatching({ debounceMs: 50 });
+
+      await fs.writeFile(
+        path.join(tmpDir, "real-fail.md"),
+        "# RealFail\n\nContent that triggers embed crash.\n",
+      );
+      watcher.emit("add", path.join(tmpDir, "real-fail.md"));
+
+      await sleep(200);
+
+      expect(indexer.failureCount).toBe(1);
+      expect(indexer.lastFailureTime).toBeInstanceOf(Date);
+      expect(indexer.lastFailureSource).toBe("real-fail.md");
+
+      const status = await indexer.getHealthStatus();
+      expect(status.failureCount).toBe(1);
+      expect(status.lastFailure).not.toBeNull();
+      expect(status.lastFailure!.source).toBe("real-fail.md");
+    });
+
+    it("health status remains clean after multiple normal deletes", async () => {
+      for (let i = 1; i <= 5; i++) {
+        await fs.writeFile(
+          path.join(tmpDir, `multi-del-${i}.md`),
+          `# File ${i}\n\nContent.\n`,
+        );
+        await indexer.indexFile(`multi-del-${i}.md`);
+      }
+
+      await indexer.startWatching({ debounceMs: 50 });
+
+      for (let i = 1; i <= 5; i++) {
+        await fs.unlink(path.join(tmpDir, `multi-del-${i}.md`));
+        watcher.emit("unlink", path.join(tmpDir, `multi-del-${i}.md`));
+      }
+
+      await sleep(300);
+
+      const status = await indexer.getHealthStatus();
+      expect(status.failureCount).toBe(0);
+      expect(status.lastFailure).toBeNull();
+      expect(status.indexingState).toBe("watching");
+    });
   });
   describe("getHealthStatus", () => {
     it("returns idle state with zero counters when freshly created", async () => {

--- a/src/use-cases/vault-indexer.ts
+++ b/src/use-cases/vault-indexer.ts
@@ -6,6 +6,7 @@ import type {
   IVectorStore,
   VectorChunk,
 } from "../domain/interfaces/index.js";
+import { NoteNotFoundError } from "../domain/errors/index.js";
 import { MarkdownChunker } from "./chunker.js";
 import { MarkdownPipeline } from "./markdown-pipeline.js";
 
@@ -192,11 +193,17 @@ export class VaultIndexer {
     for (const relPath of paths) {
       try {
         if (!(await this.fs.exists(relPath))) {
-          throw new Error("File not found");
+          // File disappeared before processing — expected removal, not a failure.
+          await this.removeFile(relPath);
+          continue;
         }
         await this.indexFile(relPath);
-      } catch {
-        // File was deleted between enqueue and process
+      } catch (error) {
+        if (isExpectedMissingNote(error)) {
+          await this.removeFile(relPath);
+          continue;
+        }
+        // Genuine indexing failure (embed/read/upsert error on an existing file).
         await this.removeFile(relPath);
       }
     }
@@ -212,10 +219,15 @@ export class VaultIndexer {
         for (const relPath of paths) {
           try {
             if (!(await this.fs.exists(relPath))) {
-              throw new Error("File not found");
+              await this.removeFile(relPath);
+              continue;
             }
             await this.indexFile(relPath);
-          } catch {
+          } catch (error) {
+            if (isExpectedMissingNote(error)) {
+              await this.removeFile(relPath);
+              continue;
+            }
             this.failureCount++;
             this.lastFailureTime = new Date();
             this.lastFailureSource = relPath;
@@ -328,4 +340,8 @@ export class VaultIndexer {
       this.resetChangeCount();
     }
   }
+}
+
+function isExpectedMissingNote(error: unknown): boolean {
+  return error instanceof NoteNotFoundError;
 }

--- a/src/use-cases/vault-scope.test.ts
+++ b/src/use-cases/vault-scope.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from "vitest";
+import {
+  MAX_SCOPE_CHARS,
+  extractVaultScopeFromFrontmatter,
+  generateVaultScope,
+} from "./vault-scope.js";
+
+describe("extractVaultScopeFromFrontmatter", () => {
+  it("extracts vault_scope from valid frontmatter", () => {
+    const content = `---
+schema_version: 1
+generated_by: mcp-markdown-vault
+generated_at: 2026-01-15T10:00:00.000Z
+managed_by: auto
+vault_scope: "12 markdown files in notes/, projects/"
+---
+
+# Vault Overview
+`;
+    expect(extractVaultScopeFromFrontmatter(content)).toBe(
+      "12 markdown files in notes/, projects/",
+    );
+  });
+
+  it("extracts unquoted vault_scope", () => {
+    const content = `---
+vault_scope: my test vault
+---
+
+# Content
+`;
+    expect(extractVaultScopeFromFrontmatter(content)).toBe("my test vault");
+  });
+
+  it("returns undefined when frontmatter is missing", () => {
+    const content = "# No Frontmatter\n\nJust content.\n";
+    expect(extractVaultScopeFromFrontmatter(content)).toBeUndefined();
+  });
+
+  it("returns undefined when frontmatter has no vault_scope field", () => {
+    const content = `---
+schema_version: 1
+managed_by: auto
+---
+
+# Content
+`;
+    expect(extractVaultScopeFromFrontmatter(content)).toBeUndefined();
+  });
+
+  it("returns undefined when vault_scope is empty string", () => {
+    const content = `---
+vault_scope: ""
+---
+
+# Content
+`;
+    expect(extractVaultScopeFromFrontmatter(content)).toBeUndefined();
+  });
+
+  it("returns undefined when vault_scope is whitespace only", () => {
+    const content = `---
+vault_scope: "   "
+---
+
+# Content
+`;
+    expect(extractVaultScopeFromFrontmatter(content)).toBeUndefined();
+  });
+
+  it("returns undefined when frontmatter is malformed YAML", () => {
+    const content = `---
+vault_scope: [unclosed
+---
+
+# Content
+`;
+    expect(extractVaultScopeFromFrontmatter(content)).toBeUndefined();
+  });
+
+  it("returns undefined when vault_scope is not a string", () => {
+    const content = `---
+vault_scope: 42
+---
+
+# Content
+`;
+    expect(extractVaultScopeFromFrontmatter(content)).toBeUndefined();
+  });
+
+  it("trims whitespace from extracted scope", () => {
+    const content = `---
+vault_scope: "  padded scope  "
+---
+
+# Content
+`;
+    expect(extractVaultScopeFromFrontmatter(content)).toBe("padded scope");
+  });
+
+  it("truncates scope exceeding MAX_SCOPE_CHARS", () => {
+    const longScope = "a".repeat(MAX_SCOPE_CHARS + 50);
+    const content = `---
+vault_scope: "${longScope}"
+---
+
+# Content
+`;
+    const result = extractVaultScopeFromFrontmatter(content);
+    expect(result).toHaveLength(MAX_SCOPE_CHARS);
+    expect(result).toBe("a".repeat(MAX_SCOPE_CHARS));
+  });
+
+  it("returns undefined when closing --- is missing", () => {
+    const content = `---
+vault_scope: "orphan"
+# Content
+`;
+    expect(extractVaultScopeFromFrontmatter(content)).toBeUndefined();
+  });
+});
+
+describe("generateVaultScope", () => {
+  it("generates scope from directories and tags", () => {
+    const result = generateVaultScope({
+      totalFiles: 42,
+      directories: [
+        { name: "notes", fileCount: 20 },
+        { name: "projects", fileCount: 15 },
+      ],
+      tags: [
+        { name: "typescript", count: 10 },
+        { name: "architecture", count: 8 },
+      ],
+    });
+
+    expect(result).toContain("42 markdown files");
+    expect(result).toContain("notes/");
+    expect(result).toContain("projects/");
+    expect(result).toContain("typescript");
+    expect(result).toContain("architecture");
+  });
+
+  it("handles empty directories and tags", () => {
+    const result = generateVaultScope({
+      totalFiles: 3,
+      directories: [],
+      tags: [],
+    });
+
+    expect(result).toBe("3 markdown files");
+  });
+
+  it("limits directories to 4", () => {
+    const result = generateVaultScope({
+      totalFiles: 100,
+      directories: [
+        { name: "a", fileCount: 30 },
+        { name: "b", fileCount: 25 },
+        { name: "c", fileCount: 20 },
+        { name: "d", fileCount: 15 },
+        { name: "e", fileCount: 10 },
+      ],
+      tags: [],
+    });
+
+    expect(result).toContain("a/");
+    expect(result).toContain("d/");
+    expect(result).not.toContain("e/");
+  });
+
+  it("limits tags to 4", () => {
+    const result = generateVaultScope({
+      totalFiles: 50,
+      directories: [],
+      tags: [
+        { name: "t1", count: 10 },
+        { name: "t2", count: 9 },
+        { name: "t3", count: 8 },
+        { name: "t4", count: 7 },
+        { name: "t5", count: 6 },
+      ],
+    });
+
+    expect(result).toContain("t4");
+    expect(result).not.toContain("t5");
+  });
+
+  it("never exceeds MAX_SCOPE_CHARS", () => {
+    const result = generateVaultScope({
+      totalFiles: 9999,
+      directories: Array.from({ length: 10 }, (_, i) => ({
+        name: "very-long-directory-name-" + "x".repeat(20) + i,
+        fileCount: 100,
+      })),
+      tags: Array.from({ length: 10 }, (_, i) => ({
+        name: "long-tag-name-" + "y".repeat(20) + i,
+        count: 50,
+      })),
+    });
+
+    expect(result.length).toBeLessThanOrEqual(MAX_SCOPE_CHARS);
+  });
+
+  it("returns single-line string (no newlines)", () => {
+    const result = generateVaultScope({
+      totalFiles: 10,
+      directories: [{ name: "docs", fileCount: 5 }],
+      tags: [{ name: "test", count: 3 }],
+    });
+
+    expect(result).not.toContain("\n");
+  });
+
+  it("is deterministic for same input", () => {
+    const data = {
+      totalFiles: 25,
+      directories: [
+        { name: "notes", fileCount: 15 },
+        { name: "archive", fileCount: 10 },
+      ],
+      tags: [
+        { name: "daily", count: 12 },
+        { name: "meeting", count: 8 },
+      ],
+    };
+
+    expect(generateVaultScope(data)).toBe(generateVaultScope(data));
+  });
+});
+
+describe("MAX_SCOPE_CHARS", () => {
+  it("is a positive number", () => {
+    expect(MAX_SCOPE_CHARS).toBeGreaterThan(0);
+  });
+
+  it("is 200", () => {
+    expect(MAX_SCOPE_CHARS).toBe(200);
+  });
+});

--- a/src/use-cases/vault-scope.ts
+++ b/src/use-cases/vault-scope.ts
@@ -1,0 +1,97 @@
+import yaml from "js-yaml";
+
+/**
+ * Maximum length for the one-line vault scope string.
+ * Used in both generation and extraction to enforce a strict cap.
+ */
+export const MAX_SCOPE_CHARS = 200;
+
+/**
+ * Extracts the `vault_scope` field from overview.md frontmatter.
+ * Returns `undefined` if frontmatter is missing, malformed, or the field is absent/empty.
+ */
+export function extractVaultScopeFromFrontmatter(content: string): string | undefined {
+  if (!content.startsWith("---\n") && !content.startsWith("---\r\n")) {
+    return undefined;
+  }
+
+  const closingIndex = content.indexOf("\n---\n", 4);
+  const closingIndexAlt = content.indexOf("\n---\r\n", 4);
+  const endIdx = closingIndex !== -1
+    ? closingIndex
+    : closingIndexAlt !== -1
+      ? closingIndexAlt
+      : -1;
+
+  if (endIdx === -1) {
+    return undefined;
+  }
+
+  const frontmatterRaw = content.slice(4, endIdx);
+
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(frontmatterRaw);
+  } catch {
+    return undefined;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    return undefined;
+  }
+
+  const scope = (parsed as Record<string, unknown>)["vault_scope"];
+  if (typeof scope !== "string") {
+    return undefined;
+  }
+
+  const trimmed = scope.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+
+  return trimmed.slice(0, MAX_SCOPE_CHARS);
+}
+
+interface VaultScopeData {
+  totalFiles: number;
+  directories: Array<{ name: string; fileCount: number }>;
+  tags: Array<{ name: string; count: number }>;
+}
+
+/**
+ * Generates a deterministic one-line vault scope description from vault statistics.
+ * Always returns a non-empty string capped at MAX_SCOPE_CHARS.
+ */
+export function generateVaultScope(data: VaultScopeData): string {
+  const parts: string[] = [];
+
+  parts.push(`${data.totalFiles} markdown files`);
+
+  const topDirs = data.directories.slice(0, 4);
+  if (topDirs.length > 0) {
+    const dirNames = topDirs.map((d) => `${d.name}/`).join(", ");
+    parts.push(`in ${dirNames}`);
+  }
+
+  const topTags = data.tags.slice(0, 4);
+  if (topTags.length > 0) {
+    const tagNames = topTags.map((t) => t.name).join(", ");
+    parts.push(`topics: ${tagNames}`);
+  }
+
+  const joined = parts.join(" — ");
+
+  if (joined.length <= MAX_SCOPE_CHARS) {
+    return joined;
+  }
+
+  // Truncate cleanly at word boundary if possible
+  const truncated = joined.slice(0, MAX_SCOPE_CHARS - 1);
+  const lastSpace = truncated.lastIndexOf(" ");
+  if (lastSpace > MAX_SCOPE_CHARS * 0.6) {
+    return truncated.slice(0, lastSpace) + "…";
+  }
+
+  return truncated + "…";
+}


### PR DESCRIPTION
- populate meta/overview.md after initial auto-mode indexing instead of leaving the stub in place
- generate and persist vault_scope in overview frontmatter as the single source of truth for host-visible vault context
- refresh overview.md and vault_scope after the meaningful-change threshold is reached
- make new MCP handshakes use the latest vault_scope value
- treat expected delete/unlink races as non-failures so normal file removals do not pollute failureCount/lastFailure
- add regression coverage for overview refresh, scope refresh, and delete TOCTOU behavior
- update README to match the current repo, config surface, and vault_scope behavior