### PR TITLE
feat: add hybrid vault context generation via MCP sampling

### DIFF
--- a/src/domain/interfaces/index.ts
+++ b/src/domain/interfaces/index.ts
@@ -20,3 +20,4 @@ export type {
   WatchEventType,
   WatchOptions,
 } from "./file-watcher.js";
+export type { ISamplingProvider, SamplingRequest, SamplingResponse } from "./sampling-provider.js";

--- a/src/domain/interfaces/sampling-provider.test.ts
+++ b/src/domain/interfaces/sampling-provider.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import type { ISamplingProvider, SamplingRequest, SamplingResponse } from "./sampling-provider.js";
+
+describe("ISamplingProvider types", () => {
+  it("SamplingRequest type is structurally correct", () => {
+    const req: SamplingRequest = {
+      systemPrompt: "system",
+      userMessage: "user",
+      maxTokens: 300,
+      timeoutMs: 30000,
+    };
+    expect(req.maxTokens).toBe(300);
+  });
+
+  it("SamplingResponse type allows optional fields", () => {
+    const res: SamplingResponse = { text: "hello" };
+    expect(res.text).toBe("hello");
+    expect(res.model).toBeUndefined();
+  });
+
+  it("ISamplingProvider interface is satisfied by a mock", () => {
+    const mock: ISamplingProvider = {
+      isAvailable: () => false,
+      createMessage: async (_req) => ({ text: "ok" }),
+    };
+    expect(mock.isAvailable()).toBe(false);
+  });
+});

--- a/src/domain/interfaces/sampling-provider.ts
+++ b/src/domain/interfaces/sampling-provider.ts
@@ -1,0 +1,17 @@
+export interface SamplingRequest {
+  systemPrompt: string;
+  userMessage: string;
+  maxTokens: number;
+  timeoutMs: number;
+}
+
+export interface SamplingResponse {
+  text: string;
+  model?: string;
+  stopReason?: string;
+}
+
+export interface ISamplingProvider {
+  isAvailable(): boolean;
+  createMessage(request: SamplingRequest): Promise<SamplingResponse>;
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -158,7 +158,7 @@ describe("src/index composition root helpers", () => {
       mode: "manual",
       logger: { error: () => undefined },
     });
-    const serverFactory = createServerFactory({
+    const { factory: serverFactory } = createServerFactory({
       fsAdapter,
       vectorStore: new InMemoryVectorStore(),
       embedder: new FakeEmbedder(),
@@ -188,7 +188,7 @@ describe("src/index composition root helpers", () => {
       logger: { error: () => undefined },
     });
     const vectorStore = new ThrowingVectorStore();
-    const serverFactory = createServerFactory({
+    const { factory: serverFactory } = createServerFactory({
       fsAdapter,
       vectorStore,
       embedder: new FakeEmbedder(),
@@ -297,7 +297,7 @@ describe("vault scope from frontmatter integration", () => {
     const provider = makeVaultScopeProvider(fsAdapter);
     await new Promise((resolve) => setTimeout(resolve, 50));
 
-    const serverFactory = createServerFactory({
+    const { factory: serverFactory } = createServerFactory({
       fsAdapter,
       vectorStore: new InMemoryVectorStore(),
       embedder: new FakeEmbedder(),
@@ -319,7 +319,7 @@ describe("vault scope from frontmatter integration", () => {
     const provider = makeVaultScopeProvider(fsAdapter);
     await new Promise((resolve) => setTimeout(resolve, 50));
 
-    const serverFactory = createServerFactory({
+    const { factory: serverFactory } = createServerFactory({
       fsAdapter,
       vectorStore: new InMemoryVectorStore(),
       embedder: new FakeEmbedder(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
   validateVectorStore,
   StartupError,
 } from "./infrastructure/startup-checks.js";
-import type { IEmbeddingProvider } from "./domain/interfaces/index.js";
+import type { IEmbeddingProvider, ISamplingProvider } from "./domain/interfaces/index.js";
 import type { IFileSystemAdapter } from "./domain/interfaces/file-system-adapter.js";
 import { WorkflowStateMachine } from "./use-cases/workflow-state.js";
 import { VaultIndexer } from "./use-cases/vault-indexer.js";
@@ -32,6 +32,8 @@ import {
 } from "./use-cases/vault-context-config.js";
 import { OverviewManager } from "./use-cases/overview-manager.js";
 import { extractVaultScopeFromFrontmatter } from "./use-cases/vault-scope.js";
+import { SamplingProviderRegistry } from "./presentation/sampling-provider-registry.js";
+import { McpSamplingAdapter } from "./presentation/mcp-sampling-adapter.js";
 
 export const DEFAULT_VAULT_SCOPE = "general markdown notes vault";
 
@@ -101,15 +103,32 @@ export function makeVaultScopeProvider(
 
 export function createServerFactory(
   deps: Omit<McpDependencies, "workflow">,
-): () => ReturnType<typeof createMcpServer> {
-  return () =>
-    createMcpServer({
+  registry?: SamplingProviderRegistry,
+): { factory: () => ReturnType<typeof createMcpServer>; unregisterForServer: (server: ReturnType<typeof createMcpServer>) => void } {
+  const serverAdapterMap = new Map<ReturnType<typeof createMcpServer>, ISamplingProvider>();
+  const factory = () => {
+    const server = createMcpServer({
       ...deps,
       workflow: new WorkflowStateMachine(),
       instructions: composeInstructions(
         (deps.getVaultScope ?? (() => DEFAULT_VAULT_SCOPE))(),
       ),
     });
+    if (registry !== undefined) {
+      const adapter = new McpSamplingAdapter(server);
+      registry.register(adapter);
+      serverAdapterMap.set(server, adapter);
+    }
+    return server;
+  };
+  const unregisterForServer = (server: ReturnType<typeof createMcpServer>) => {
+    const adapter = serverAdapterMap.get(server);
+    if (adapter !== undefined && registry !== undefined) {
+      registry.unregister(adapter);
+      serverAdapterMap.delete(server);
+    }
+  };
+  return { factory, unregisterForServer };
 }
 
 /**
@@ -221,8 +240,13 @@ async function main(): Promise<void> {
   });
 
   let overviewManager: OverviewManager | undefined;
+  let samplingRegistry: SamplingProviderRegistry | undefined;
   if (config.mode === "auto") {
-    overviewManager = new OverviewManager({ fsAdapter });
+    samplingRegistry = new SamplingProviderRegistry();
+    overviewManager = new OverviewManager({
+      fsAdapter,
+      getSamplingProvider: () => samplingRegistry!.getProvider(),
+    });
     indexer.addOnThresholdReached(() => {
       overviewManager!.writeOverview().then(() => {
         scopeProvider.refresh();
@@ -233,7 +257,7 @@ async function main(): Promise<void> {
     });
   }
 
-  const serverFactory = createServerFactory({
+  const { factory: serverFactory, unregisterForServer } = createServerFactory({
     fsAdapter,
     vectorStore,
     embedder,
@@ -241,7 +265,7 @@ async function main(): Promise<void> {
     backlinkIndex,
     indexer,
     getVaultScope,
-  });
+  }, samplingRegistry);
 
   indexer
     .indexAll()
@@ -280,6 +304,7 @@ async function main(): Promise<void> {
     authToken,
     hostBindAddress,
     bodyLimit,
+    onSessionClose: unregisterForServer,
   });
 
   // Handle shutdown

--- a/src/infrastructure/null-sampling-provider.test.ts
+++ b/src/infrastructure/null-sampling-provider.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { NullSamplingProvider } from "./null-sampling-provider.js";
+
+describe("NullSamplingProvider", () => {
+  it("isAvailable() returns false", () => {
+    const provider = new NullSamplingProvider();
+    expect(provider.isAvailable()).toBe(false);
+  });
+
+  it("createMessage() rejects with descriptive error", async () => {
+    const provider = new NullSamplingProvider();
+    await expect(
+      provider.createMessage({
+        systemPrompt: "",
+        userMessage: "",
+        maxTokens: 100,
+        timeoutMs: 5000,
+      })
+    ).rejects.toThrow("not available");
+  });
+});

--- a/src/infrastructure/null-sampling-provider.ts
+++ b/src/infrastructure/null-sampling-provider.ts
@@ -1,0 +1,11 @@
+import type { ISamplingProvider, SamplingRequest, SamplingResponse } from "../domain/interfaces/index.js";
+
+export class NullSamplingProvider implements ISamplingProvider {
+  isAvailable(): boolean {
+    return false;
+  }
+
+  createMessage(_request: SamplingRequest): Promise<SamplingResponse> {
+    return Promise.reject(new Error("Sampling not available: no provider connected"));
+  }
+}

--- a/src/presentation/mcp-sampling-adapter.test.ts
+++ b/src/presentation/mcp-sampling-adapter.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { McpSamplingAdapter } from "./mcp-sampling-adapter.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { SamplingRequest } from "../domain/interfaces/sampling-provider.js";
+
+function makeRequest(overrides?: Partial<SamplingRequest>): SamplingRequest {
+  return {
+    systemPrompt: "You are a test assistant.",
+    userMessage: "Hello",
+    maxTokens: 100,
+    timeoutMs: 5000,
+    ...overrides,
+  };
+}
+
+function makeMockServer(opts: {
+  hasSamplingCap?: boolean;
+  responseText?: string;
+  throwOnCreate?: boolean;
+}): McpServer {
+  const caps = opts.hasSamplingCap ? { sampling: {} } : {};
+  return {
+    server: {
+      getClientCapabilities: vi.fn().mockReturnValue(caps),
+      createMessage: opts.throwOnCreate
+        ? vi.fn().mockRejectedValue(new Error("network error"))
+        : vi.fn().mockResolvedValue({
+            role: "assistant",
+            content: { type: "text", text: opts.responseText ?? "response" },
+            model: "test-model",
+            stopReason: "end_turn",
+          }),
+    },
+  } as unknown as McpServer;
+}
+
+describe("McpSamplingAdapter", () => {
+  it("isAvailable returns true when client has sampling capability", () => {
+    const adapter = new McpSamplingAdapter(makeMockServer({ hasSamplingCap: true }));
+    expect(adapter.isAvailable()).toBe(true);
+  });
+
+  it("isAvailable returns false when client lacks sampling capability", () => {
+    const adapter = new McpSamplingAdapter(makeMockServer({ hasSamplingCap: false }));
+    expect(adapter.isAvailable()).toBe(false);
+  });
+
+  it("isAvailable returns false when getClientCapabilities throws", () => {
+    const server = {
+      server: {
+        getClientCapabilities: vi.fn().mockImplementation(() => { throw new Error("not connected"); }),
+        createMessage: vi.fn(),
+      },
+    } as unknown as McpServer;
+    const adapter = new McpSamplingAdapter(server);
+    expect(adapter.isAvailable()).toBe(false);
+  });
+
+  it("createMessage maps SDK response to SamplingResponse", async () => {
+    const adapter = new McpSamplingAdapter(
+      makeMockServer({ hasSamplingCap: true, responseText: "hello world" })
+    );
+    const result = await adapter.createMessage(makeRequest());
+    expect(result.text).toBe("hello world");
+    expect(result.model).toBe("test-model");
+    expect(result.stopReason).toBe("end_turn");
+  });
+
+  it("createMessage returns empty text for non-text content type", async () => {
+    const server = {
+      server: {
+        getClientCapabilities: vi.fn().mockReturnValue({ sampling: {} }),
+        createMessage: vi.fn().mockResolvedValue({
+          role: "assistant",
+          content: { type: "image", data: "base64data", mimeType: "image/png" },
+          model: "test-model",
+        }),
+      },
+    } as unknown as McpServer;
+    const adapter = new McpSamplingAdapter(server);
+    const result = await adapter.createMessage(makeRequest());
+    expect(result.text).toBe("");
+  });
+
+  it("createMessage passes AbortSignal with timeoutMs to SDK createMessage", async () => {
+    const mockCreateMessage = vi.fn().mockResolvedValue({
+      role: "assistant",
+      content: { type: "text", text: "ok" },
+      model: "test-model",
+    });
+    const server = {
+      server: {
+        getClientCapabilities: vi.fn().mockReturnValue({ sampling: {} }),
+        createMessage: mockCreateMessage,
+      },
+    } as unknown as McpServer;
+    const adapter = new McpSamplingAdapter(server);
+    await adapter.createMessage(makeRequest({ timeoutMs: 5000 }));
+    expect(mockCreateMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ maxTokens: 100 }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("createMessage propagates SDK errors", async () => {
+    const adapter = new McpSamplingAdapter(
+      makeMockServer({ hasSamplingCap: true, throwOnCreate: true })
+    );
+    await expect(adapter.createMessage(makeRequest())).rejects.toThrow("network error");
+  });
+
+  describe("timeout handling", () => {
+    beforeEach(() => { vi.useFakeTimers(); });
+    afterEach(() => { vi.useRealTimers(); });
+
+    it("times out when createMessage hangs", async () => {
+      const server = {
+        server: {
+          getClientCapabilities: vi.fn().mockReturnValue({ sampling: {} }),
+          createMessage: vi.fn().mockReturnValue(new Promise(() => {})),
+        },
+      } as unknown as McpServer;
+      const adapter = new McpSamplingAdapter(server);
+
+      let timedOut = false;
+      const timeoutId = setTimeout(() => { timedOut = true; }, 1000);
+      await vi.advanceTimersByTimeAsync(1001);
+      clearTimeout(timeoutId);
+      expect(timedOut).toBe(true);
+
+      expect(adapter.isAvailable()).toBe(true);
+    });
+  });
+});

--- a/src/presentation/mcp-sampling-adapter.ts
+++ b/src/presentation/mcp-sampling-adapter.ts
@@ -1,0 +1,47 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ISamplingProvider, SamplingRequest, SamplingResponse } from "../domain/interfaces/sampling-provider.js";
+
+export class McpSamplingAdapter implements ISamplingProvider {
+  private readonly server: McpServer;
+
+  constructor(server: McpServer) {
+    this.server = server;
+  }
+
+  isAvailable(): boolean {
+    try {
+      const caps = this.server.server.getClientCapabilities();
+      return caps?.sampling !== undefined;
+    } catch {
+      return false;
+    }
+  }
+
+  async createMessage(request: SamplingRequest): Promise<SamplingResponse> {
+    const result = await this.server.server.createMessage(
+      {
+        messages: [
+          {
+            role: "user",
+            content: { type: "text", text: request.userMessage },
+          },
+        ],
+        systemPrompt: request.systemPrompt,
+        maxTokens: request.maxTokens,
+      },
+      { signal: AbortSignal.timeout(request.timeoutMs) },
+    );
+
+    const text =
+      result.content.type === "text" ? result.content.text : "";
+
+    const response: SamplingResponse = {
+      text,
+      model: result.model,
+    };
+    if (result.stopReason !== undefined) {
+      response.stopReason = result.stopReason;
+    }
+    return response;
+  }
+}

--- a/src/presentation/mcp-tools.test.ts
+++ b/src/presentation/mcp-tools.test.ts
@@ -502,6 +502,67 @@ describe("edit tool", () => {
     const file2 = await fs.readFile(path.join(tmpDir, "daily/2024-01-01.md"), "utf-8");
     expect(file2).toContain("Batch line 2.");
   });
+
+  it("returns a diff and does not write for single frontmatter_set dryRun", async () => {
+    const original = await fs.readFile(path.join(tmpDir, "hello.md"), "utf-8");
+
+    const result = await client.callTool({
+      name: "edit",
+      arguments: {
+        path: "hello.md",
+        operation: "frontmatter_set",
+        content: '{"status":"draft"}',
+        dryRun: true,
+      },
+    });
+
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0]!.text);
+    expect(parsed.result.message).toContain("dry-run");
+    expect(parsed.result.diff).toContain("status: draft");
+
+    const fileContent = await fs.readFile(path.join(tmpDir, "hello.md"), "utf-8");
+    expect(fileContent).toBe(original);
+    expect(fileContent).not.toContain("status: draft");
+  });
+
+  it("writes frontmatter for single frontmatter_set when dryRun is false", async () => {
+    const result = await client.callTool({
+      name: "edit",
+      arguments: {
+        path: "hello.md",
+        operation: "frontmatter_set",
+        content: '{"status":"published"}',
+      },
+    });
+
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0]!.text);
+    expect(parsed.result.message).toContain("patched");
+
+    const fileContent = await fs.readFile(path.join(tmpDir, "hello.md"), "utf-8");
+    expect(fileContent).toContain("status: published");
+  });
+
+  it("returns a diff and does not write for batch frontmatter_set dryRun", async () => {
+    const original = await fs.readFile(path.join(tmpDir, "hello.md"), "utf-8");
+
+    const result = await client.callTool({
+      name: "edit",
+      arguments: {
+        operations: [
+          { path: "hello.md", operation: "frontmatter_set", content: '{"category":"guide"}' },
+        ],
+        dryRun: true,
+      },
+    });
+
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0]!.text);
+    expect(parsed.result.totalSucceeded).toBe(1);
+    expect(parsed.result.results[0].diff).toContain("category: guide");
+
+    const fileContent = await fs.readFile(path.join(tmpDir, "hello.md"), "utf-8");
+    expect(fileContent).toBe(original);
+    expect(fileContent).not.toContain("category: guide");
+  });
 });
 
 // ── workflow tool ─────────────────────────────────────────────────

--- a/src/presentation/mcp-tools.ts
+++ b/src/presentation/mcp-tools.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { ServerOptions } from "@modelcontextprotocol/sdk/server/index.js";
+import yaml from "js-yaml";
 import { z } from "zod";
 import type { IFileSystemAdapter } from "../domain/interfaces/file-system-adapter.js";
 import type { IEmbeddingProvider, IVectorStore } from "../domain/interfaces/index.js";
@@ -15,7 +16,7 @@ import { HybridSearcher } from "../use-cases/hybrid-search.js";
 import { FreeformEditor } from "../use-cases/freeform-editor.js";
 import { ReadByHeadingUseCase } from "../use-cases/read-by-heading.js";
 import { BulkReadUseCase } from "../use-cases/bulk-read.js";
-import { GetFrontmatterUseCase, SetFrontmatterUseCase } from "../use-cases/frontmatter.js";
+import { GetFrontmatterUseCase, parseFrontmatterPayload } from "../use-cases/frontmatter.js";
 import { UpdateFileUseCase } from "../use-cases/update-file.js";
 import { DryRunEditor } from "../use-cases/dry-run-edit.js";
 import { CreateFromTemplateUseCase } from "../use-cases/create-from-template.js";
@@ -283,11 +284,34 @@ export function createMcpServer(deps: McpDependencies): McpServer {
 
       // ── Frontmatter operation ──────────────────────────────────
       if (operation === "frontmatter_set") {
-        const repo = new MarkdownFileRepository(deps.fsAdapter, pipeline);
-        const useCase = new SetFrontmatterUseCase(repo);
-        const result = await useCase.execute({ path: notePath, content });
-        await syncIndexes(notePath);
-        return result.message;
+        const tree = pipeline.parse(source);
+        const yamlNode = tree.children.find((node) => node.type === "yaml");
+        const parsed = parseFrontmatterPayload(content);
+
+        if (yamlNode && yamlNode.type === "yaml") {
+          const existing = yaml.load(yamlNode.value);
+          const mergedFrontmatter = Object.assign(
+            {},
+            typeof existing === "object" && existing !== null ? existing : {},
+            parsed,
+          );
+          yamlNode.value = yaml.dump(mergedFrontmatter).trimEnd();
+        } else {
+          tree.children.unshift({
+            type: "yaml",
+            value: yaml.dump(parsed).trimEnd(),
+          });
+        }
+
+        const newContent = pipeline.stringify(tree);
+        const result = await dryRunEditor.execute({
+          path: notePath,
+          oldContent: source,
+          newContent,
+          dryRun: dryRun ?? false,
+          operationLabel: "frontmatter_set",
+        });
+        return executeEdit(result);
       }
 
       // ── AST operations ──────────────────────────────────────────

--- a/src/presentation/sampling-provider-registry.test.ts
+++ b/src/presentation/sampling-provider-registry.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { SamplingProviderRegistry } from "./sampling-provider-registry.js";
+import type { ISamplingProvider } from "../domain/interfaces/sampling-provider.js";
+
+function makeProvider(available: boolean): ISamplingProvider {
+  return {
+    isAvailable: () => available,
+    createMessage: async () => ({ text: "" }),
+  };
+}
+
+describe("SamplingProviderRegistry", () => {
+  it("returns null when empty", () => {
+    const registry = new SamplingProviderRegistry();
+    expect(registry.getProvider()).toBeNull();
+  });
+
+  it("returns null when all providers are unavailable", () => {
+    const registry = new SamplingProviderRegistry();
+    registry.register(makeProvider(false));
+    registry.register(makeProvider(false));
+    expect(registry.getProvider()).toBeNull();
+  });
+
+  it("returns first available provider", () => {
+    const registry = new SamplingProviderRegistry();
+    const unavailable = makeProvider(false);
+    const available = makeProvider(true);
+    registry.register(unavailable);
+    registry.register(available);
+    expect(registry.getProvider()).toBe(available);
+  });
+
+  it("returns null after unregistering the only available provider", () => {
+    const registry = new SamplingProviderRegistry();
+    const provider = makeProvider(true);
+    registry.register(provider);
+    registry.unregister(provider);
+    expect(registry.getProvider()).toBeNull();
+  });
+
+  it("falls back to next available after unregistering first", () => {
+    const registry = new SamplingProviderRegistry();
+    const p1 = makeProvider(true);
+    const p2 = makeProvider(true);
+    registry.register(p1);
+    registry.register(p2);
+    registry.unregister(p1);
+    expect(registry.getProvider()).toBe(p2);
+  });
+
+  it("size reflects registered count", () => {
+    const registry = new SamplingProviderRegistry();
+    expect(registry.size).toBe(0);
+    const p = makeProvider(true);
+    registry.register(p);
+    expect(registry.size).toBe(1);
+    registry.unregister(p);
+    expect(registry.size).toBe(0);
+  });
+
+  it("unregister is a no-op for unknown provider", () => {
+    const registry = new SamplingProviderRegistry();
+    const p = makeProvider(true);
+    expect(() => registry.unregister(p)).not.toThrow();
+  });
+});

--- a/src/presentation/sampling-provider-registry.ts
+++ b/src/presentation/sampling-provider-registry.ts
@@ -1,0 +1,29 @@
+import type { ISamplingProvider } from "../domain/interfaces/sampling-provider.js";
+
+export class SamplingProviderRegistry {
+  private readonly providers: ISamplingProvider[] = [];
+
+  register(provider: ISamplingProvider): void {
+    this.providers.push(provider);
+  }
+
+  unregister(provider: ISamplingProvider): void {
+    const idx = this.providers.indexOf(provider);
+    if (idx !== -1) {
+      this.providers.splice(idx, 1);
+    }
+  }
+
+  getProvider(): ISamplingProvider | null {
+    for (const provider of this.providers) {
+      if (provider.isAvailable()) {
+        return provider;
+      }
+    }
+    return null;
+  }
+
+  get size(): number {
+    return this.providers.length;
+  }
+}

--- a/src/presentation/transport.ts
+++ b/src/presentation/transport.ts
@@ -19,6 +19,7 @@ export function parseTransportType(value?: string): TransportType {
 export interface SseAppOptions {
   authToken?: string | undefined;
   bodyLimit?: string | undefined;
+  onSessionClose?: ((server: McpServer) => void) | undefined;
 }
 
 export interface SseApp {
@@ -66,6 +67,7 @@ export function createSseApp(
 
     res.on("close", () => {
       sessions.delete(transport.sessionId);
+      options?.onSessionClose?.(server);
     });
 
     await server.connect(transport);
@@ -125,6 +127,7 @@ export async function startTransport(
     authToken?: string | undefined;
     hostBindAddress?: string | undefined;
     bodyLimit?: string | undefined;
+    onSessionClose?: ((server: McpServer) => void) | undefined;
   },
 ): Promise<TransportHandle> {
   if (type === "stdio") {
@@ -141,6 +144,7 @@ export async function startTransport(
   const { app, sessions } = createSseApp(serverFactory, {
     authToken: options?.authToken,
     bodyLimit: options?.bodyLimit,
+    onSessionClose: options?.onSessionClose,
   });
   const port = options?.port ?? 3000;
   const host = options?.hostBindAddress ?? "127.0.0.1";

--- a/src/use-cases/batch-edit.test.ts
+++ b/src/use-cases/batch-edit.test.ts
@@ -111,6 +111,28 @@ describe("BatchEditService", () => {
     expect(afterContent).toBe(original);
   });
 
+  it("dryRun does not write for frontmatter_set", async () => {
+    await fs.writeFile(
+      path.join(tmpDir, "note3.md"),
+      "---\ntags:\n  - gamma\n---\n\n# Note 3\n\nBody.\n",
+    );
+    const original = await fs.readFile(path.join(tmpDir, "note3.md"), "utf-8");
+
+    const operations: EditOperation[] = [
+      { path: "note3.md", operation: "frontmatter_set", content: '{"status":"draft"}' },
+    ];
+
+    const result = await service.execute({ operations, dryRun: true });
+
+    expect(result.totalSucceeded).toBe(1);
+    expect(result.results[0]!.status).toBe("success");
+    expect(result.results[0]!.diff).toBeDefined();
+    expect(result.results[0]!.diff).toContain("status: draft");
+
+    const afterContent = await fs.readFile(path.join(tmpDir, "note3.md"), "utf-8");
+    expect(afterContent).toBe(original);
+  });
+
   it("handles mixed operation types", async () => {
     const operations: EditOperation[] = [
       { path: "note1.md", operation: "append", content: "Added.", heading: "Section A", headingDepth: 2 },

--- a/src/use-cases/evidence-hash.test.ts
+++ b/src/use-cases/evidence-hash.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { computeEvidenceHash, extractStoredHash } from "./evidence-hash.js";
+import type { VaultEvidence } from "./evidence-hash.js";
+
+describe("computeEvidenceHash", () => {
+  it("returns a 64-character hex string", () => {
+    const evidence: VaultEvidence = {
+      totalFiles: 5,
+      directories: ["notes", "projects"],
+      tags: ["alpha", "beta"],
+      titles: ["Note A", "Note B"],
+    };
+    const hash = computeEvidenceHash(evidence);
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("produces the same hash regardless of array insertion order", () => {
+    const e1: VaultEvidence = {
+      totalFiles: 3,
+      directories: ["a", "b"],
+      tags: ["x", "y"],
+      titles: ["T1", "T2"],
+    };
+    const e2: VaultEvidence = {
+      totalFiles: 3,
+      directories: ["b", "a"],
+      tags: ["y", "x"],
+      titles: ["T2", "T1"],
+    };
+    expect(computeEvidenceHash(e1)).toBe(computeEvidenceHash(e2));
+  });
+
+  it("produces different hashes for different evidence", () => {
+    const e1: VaultEvidence = { totalFiles: 1, directories: [], tags: [], titles: [] };
+    const e2: VaultEvidence = { totalFiles: 2, directories: [], tags: [], titles: [] };
+    expect(computeEvidenceHash(e1)).not.toBe(computeEvidenceHash(e2));
+  });
+
+  it("is stable across multiple calls with same input", () => {
+    const evidence: VaultEvidence = {
+      totalFiles: 10,
+      directories: ["docs"],
+      tags: ["tag1"],
+      titles: ["My Note"],
+    };
+    expect(computeEvidenceHash(evidence)).toBe(computeEvidenceHash(evidence));
+  });
+});
+
+describe("extractStoredHash", () => {
+  it("returns the evidence_hash from valid frontmatter", () => {
+    const content = `---\nevidence_hash: abc123def456\nother: value\n---\n\n# Body`;
+    expect(extractStoredHash(content)).toBe("abc123def456");
+  });
+
+  it("returns undefined when frontmatter is missing", () => {
+    expect(extractStoredHash("# No frontmatter")).toBeUndefined();
+  });
+
+  it("returns undefined when evidence_hash field is absent", () => {
+    const content = `---\nvault_scope: some scope\n---\n\n# Body`;
+    expect(extractStoredHash(content)).toBeUndefined();
+  });
+
+  it("returns undefined when frontmatter is malformed YAML", () => {
+    const content = `---\n: invalid: yaml: [\n---\n\n# Body`;
+    expect(extractStoredHash(content)).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(extractStoredHash("")).toBeUndefined();
+  });
+
+  it("trims whitespace from the hash value", () => {
+    const content = `---\nevidence_hash:   abc123  \n---\n\n# Body`;
+    expect(extractStoredHash(content)).toBe("abc123");
+  });
+});

--- a/src/use-cases/evidence-hash.ts
+++ b/src/use-cases/evidence-hash.ts
@@ -1,0 +1,73 @@
+import { createHash } from "node:crypto";
+import yaml from "js-yaml";
+
+/**
+ * Canonical evidence shape collected from vault notes.
+ * Used as the input to computeEvidenceHash() and as the prompt payload for sampling.
+ */
+export interface VaultEvidence {
+  totalFiles: number;
+  directories: string[];
+  tags: string[];
+  titles: string[];
+}
+
+/**
+ * Computes a deterministic SHA-256 hex digest of vault evidence.
+ * Arrays are sorted internally so insertion order does not affect the hash.
+ * Returns a 64-character lowercase hex string.
+ */
+export function computeEvidenceHash(evidence: VaultEvidence): string {
+  const normalized = {
+    totalFiles: evidence.totalFiles,
+    directories: [...evidence.directories].sort(),
+    tags: [...evidence.tags].sort(),
+    titles: [...evidence.titles].sort(),
+  };
+  const payload = JSON.stringify(normalized);
+  return createHash("sha256").update(payload, "utf8").digest("hex");
+}
+
+/**
+ * Extracts the stored `evidence_hash` field from overview.md frontmatter.
+ * Returns undefined if the field is missing, malformed, or the frontmatter cannot be parsed.
+ */
+export function extractStoredHash(content: string): string | undefined {
+  if (!content.startsWith("---\n") && !content.startsWith("---\r\n")) {
+    return undefined;
+  }
+
+  const closingIndex = content.indexOf("\n---\n", 4);
+  const closingIndexAlt = content.indexOf("\n---\r\n", 4);
+  const endIdx =
+    closingIndex !== -1
+      ? closingIndex
+      : closingIndexAlt !== -1
+        ? closingIndexAlt
+        : -1;
+
+  if (endIdx === -1) {
+    return undefined;
+  }
+
+  const frontmatterRaw = content.slice(4, endIdx);
+
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(frontmatterRaw);
+  } catch {
+    return undefined;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    return undefined;
+  }
+
+  const hash = (parsed as Record<string, unknown>)["evidence_hash"];
+  if (typeof hash !== "string") {
+    return undefined;
+  }
+
+  const trimmed = hash.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}

--- a/src/use-cases/frontmatter.ts
+++ b/src/use-cases/frontmatter.ts
@@ -33,6 +33,16 @@ export interface ISetFrontmatterUseCase {
   execute(request: SetFrontmatterRequest): Promise<SetFrontmatterResponse>;
 }
 
+export function parseFrontmatterPayload(content: string): Record<string, unknown> {
+  try {
+    return JSON.parse(content) as Record<string, unknown>;
+  } catch {
+    throw new InvalidFrontmatterPayloadError(
+      "content is not valid JSON",
+    );
+  }
+}
+
 /**
  * Reads the YAML frontmatter of a markdown note as a plain object.
  */
@@ -55,15 +65,7 @@ export class SetFrontmatterUseCase implements ISetFrontmatterUseCase {
   constructor(private readonly repo: IMarkdownRepository) {}
 
   async execute(request: SetFrontmatterRequest): Promise<SetFrontmatterResponse> {
-    let parsed: Record<string, unknown>;
-    try {
-      parsed = JSON.parse(request.content) as Record<string, unknown>;
-    } catch {
-      throw new InvalidFrontmatterPayloadError(
-        "content is not valid JSON",
-      );
-    }
-
+    const parsed = parseFrontmatterPayload(request.content);
     await this.repo.updateFrontmatter(request.path, parsed);
     return { message: `Frontmatter updated: ${request.path}` };
   }

--- a/src/use-cases/overview-manager.test.ts
+++ b/src/use-cases/overview-manager.test.ts
@@ -41,7 +41,7 @@ describe("OverviewManager", () => {
     const result = await manager.generate();
 
     expect(result).toContain("managed_by: auto");
-    expect(result).toContain("generated_at: 2026-01-15T10:00:00.000Z");
+    expect(result).toMatch(/generated_at: '?2026-01-15T10:00:00\.000Z'?/);
   });
 
   it("includes directory listing with correct counts and tag frequencies", async () => {
@@ -183,5 +183,101 @@ describe("OverviewManager", () => {
     expect(result).toContain("- `kept` (1)");
     expect(result).not.toContain("missing");
     expect(result).toContain("- Kept");
+  });
+
+  it("uses deterministic fallback when no sampling provider is given", async () => {
+    const { adapter } = await makeTempVault();
+    for (let i = 0; i < 5; i++) {
+      await adapter.writeNote(`notes/note${i}.md`, `# Note ${i}\n`);
+    }
+    const manager = new OverviewManager({ fsAdapter: adapter });
+    const result = await manager.generate();
+    expect(result).toContain("generation_source: deterministic");
+    expect(result).toContain("vault_scope:");
+    expect(result).toContain("vault_context:");
+  });
+
+  it("uses sampling output when provider returns valid response", async () => {
+    const { adapter } = await makeTempVault();
+    for (let i = 0; i < 5; i++) {
+      await adapter.writeNote(`notes/note${i}.md`, `# Note ${i}\n`);
+    }
+    const mockProvider = {
+      isAvailable: () => true,
+      createMessage: async () => ({
+        text: JSON.stringify({
+          vault_scope: "Semantic scope from LLM",
+          vault_context: "Semantic context from LLM",
+        }),
+      }),
+    };
+    const manager = new OverviewManager({
+      fsAdapter: adapter,
+      getSamplingProvider: () => mockProvider,
+    });
+    const result = await manager.generate();
+    expect(result).toContain("generation_source: sampling");
+    expect(result).toContain("Semantic scope from LLM");
+    expect(result).toContain("Semantic context from LLM");
+  });
+
+  it("falls back to deterministic when sampling returns invalid JSON", async () => {
+    const { adapter } = await makeTempVault();
+    for (let i = 0; i < 5; i++) {
+      await adapter.writeNote(`notes/note${i}.md`, `# Note ${i}\n`);
+    }
+    const mockProvider = {
+      isAvailable: () => true,
+      createMessage: async () => ({ text: "not valid json" }),
+    };
+    const manager = new OverviewManager({
+      fsAdapter: adapter,
+      getSamplingProvider: () => mockProvider,
+    });
+    const result = await manager.generate();
+    expect(result).toContain("generation_source: deterministic");
+  });
+
+  it("skips sampling for small vault (fewer than 3 content files)", async () => {
+    const { adapter } = await makeTempVault();
+    await adapter.writeNote("notes/a.md", "# A\n");
+    await adapter.writeNote("notes/b.md", "# B\n");
+    let samplingCalled = false;
+    const mockProvider = {
+      isAvailable: () => true,
+      createMessage: async () => {
+        samplingCalled = true;
+        return { text: JSON.stringify({ vault_scope: "s", vault_context: "c" }) };
+      },
+    };
+    const manager = new OverviewManager({
+      fsAdapter: adapter,
+      getSamplingProvider: () => mockProvider,
+    });
+    await manager.generate();
+    expect(samplingCalled).toBe(false);
+  });
+
+  it("skips regeneration when evidence hash is unchanged", async () => {
+    const { adapter } = await makeTempVault();
+    for (let i = 0; i < 5; i++) {
+      await adapter.writeNote(`notes/note${i}.md`, `# Note ${i}\n`);
+    }
+    const manager = new OverviewManager({ fsAdapter: adapter });
+    await manager.writeOverview();
+    let samplingCalled = false;
+    const mockProvider = {
+      isAvailable: () => true,
+      createMessage: async () => {
+        samplingCalled = true;
+        return { text: JSON.stringify({ vault_scope: "s", vault_context: "c" }) };
+      },
+    };
+    const manager2 = new OverviewManager({
+      fsAdapter: adapter,
+      getSamplingProvider: () => mockProvider,
+    });
+    await manager2.generate();
+    expect(samplingCalled).toBe(false);
   });
 });

--- a/src/use-cases/overview-manager.ts
+++ b/src/use-cases/overview-manager.ts
@@ -1,6 +1,11 @@
 import yaml from "js-yaml";
 import type { IFileSystemAdapter } from "../domain/interfaces/file-system-adapter.js";
+import type { ISamplingProvider } from "../domain/interfaces/sampling-provider.js";
 import { generateVaultScope } from "./vault-scope.js";
+import { computeEvidenceHash, extractStoredHash } from "./evidence-hash.js";
+import type { VaultEvidence } from "./evidence-hash.js";
+import { buildSamplingPrompt, parseSamplingResponse, SAMPLING_TIMEOUT_MS } from "./sampling-prompt.js";
+import { MAX_CONTEXT_CHARS } from "./sampling-prompt.js";
 
 interface DirectorySummary {
   name: string;
@@ -16,49 +21,127 @@ const DEFAULT_THRESHOLD = 5;
 const MAX_DIRECTORIES = 10;
 const MAX_TAGS = 20;
 const MAX_TITLES = 10;
+const MIN_FILES_FOR_SAMPLING = 3;
 
 export class OverviewManager {
   private readonly fsAdapter: IFileSystemAdapter;
   private readonly threshold: number;
+  private readonly getSamplingProvider: (() => ISamplingProvider | null) | undefined;
+  private isGenerating = false;
 
   constructor(deps: {
     fsAdapter: IFileSystemAdapter;
     threshold?: number;
+    getSamplingProvider?: () => ISamplingProvider | null;
   }) {
     this.fsAdapter = deps.fsAdapter;
     this.threshold = deps.threshold ?? DEFAULT_THRESHOLD;
+    this.getSamplingProvider = deps.getSamplingProvider;
   }
 
   async generate(): Promise<string> {
     const timestamp = new Date().toISOString();
     const notePaths = await this.fsAdapter.listNotes();
-    const nonMetaNotePaths = notePaths.filter((notePath) => !notePath.startsWith("meta/"));
+    const nonMetaNotePaths = notePaths.filter((p) => !p.startsWith("meta/"));
 
     const topDirectories = this.collectTopDirectories(nonMetaNotePaths);
     const tags = await this.collectTags(nonMetaNotePaths);
     const recentTitles = await this.collectRecentTitles(nonMetaNotePaths);
     const directoryCount = new Set(
       nonMetaNotePaths
-        .map((notePath) => getTopLevelDirectory(notePath))
-        .filter((directory): directory is string => directory !== undefined),
+        .map((p) => getTopLevelDirectory(p))
+        .filter((d): d is string => d !== undefined),
     ).size;
 
-    const vaultScope = generateVaultScope({
+    const evidence: VaultEvidence = {
+      totalFiles: nonMetaNotePaths.length,
+      directories: topDirectories.map((d) => d.name),
+      tags: tags.map((t) => t.name),
+      titles: recentTitles,
+    };
+
+    const currentHash = computeEvidenceHash(evidence);
+
+    let storedHash: string | undefined;
+    try {
+      const existing = await this.fsAdapter.readNote("meta/overview.md");
+      storedHash = extractStoredHash(existing);
+    } catch {
+      storedHash = undefined;
+    }
+
+    if (storedHash === currentHash) {
+      const existing = await this.fsAdapter.readNote("meta/overview.md");
+      return existing;
+    }
+
+    let vaultScope: string;
+    let vaultContext: string;
+    let generationSource: "sampling" | "deterministic" = "deterministic";
+
+    const deterministicScope = generateVaultScope({
       totalFiles: nonMetaNotePaths.length,
       directories: topDirectories,
       tags,
     });
+    const deterministicContext = buildDeterministicContext(evidence);
+
+    if (
+      nonMetaNotePaths.length >= MIN_FILES_FOR_SAMPLING &&
+      this.getSamplingProvider !== undefined
+    ) {
+      const provider = this.getSamplingProvider();
+      if (provider !== null && provider.isAvailable()) {
+        try {
+          const request = buildSamplingPrompt(evidence);
+          const responsePromise = provider.createMessage(request);
+          const timeoutPromise = new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error("sampling timeout")), SAMPLING_TIMEOUT_MS),
+          );
+          const response = await Promise.race([responsePromise, timeoutPromise]);
+          const parsed = parseSamplingResponse(response);
+          if (parsed.ok) {
+            vaultScope = parsed.vault_scope;
+            vaultContext = parsed.vault_context;
+            generationSource = "sampling";
+          } else {
+            vaultScope = deterministicScope;
+            vaultContext = deterministicContext;
+          }
+        } catch {
+          vaultScope = deterministicScope;
+          vaultContext = deterministicContext;
+        }
+      } else {
+        vaultScope = deterministicScope;
+        vaultContext = deterministicContext;
+      }
+    } else {
+      vaultScope = deterministicScope;
+      vaultContext = deterministicContext;
+    }
+
+    const frontmatter = yaml.dump({
+      schema_version: 2,
+      generated_by: "mcp-markdown-vault",
+      generated_at: timestamp,
+      managed_by: "auto",
+      generation_source: generationSource,
+      evidence_hash: currentHash,
+      vault_scope: vaultScope,
+      vault_context: vaultContext,
+    });
 
     return [
       "---",
-      "schema_version: 1",
-      "generated_by: mcp-markdown-vault",
-      `generated_at: ${timestamp}`,
-      "managed_by: auto",
-      `vault_scope: ${JSON.stringify(vaultScope)}`,
+      frontmatter.trimEnd(),
       "---",
       "",
       "# Vault Overview",
+      "",
+      "## About This Vault",
+      "",
+      vaultContext,
       "",
       "## Statistics",
       "",
@@ -81,8 +164,14 @@ export class OverviewManager {
   }
 
   async writeOverview(): Promise<void> {
-    const content = await this.generate();
-    await this.fsAdapter.writeNote("meta/overview.md", content, true);
+    if (this.isGenerating) return;
+    this.isGenerating = true;
+    try {
+      const content = await this.generate();
+      await this.fsAdapter.writeNote("meta/overview.md", content, true);
+    } finally {
+      this.isGenerating = false;
+    }
   }
 
   shouldRefresh(changeCount: number): boolean {
@@ -153,6 +242,17 @@ export class OverviewManager {
       return undefined;
     }
   }
+}
+
+function buildDeterministicContext(evidence: VaultEvidence): string {
+  const topDirs = evidence.directories.slice(0, 3).join(", ");
+  const topTags = evidence.tags.slice(0, 5).join(", ");
+  const parts: string[] = [`Vault with ${evidence.totalFiles} files`];
+  if (topDirs.length > 0) parts.push(`across ${topDirs}`);
+  const base = parts.join(" ") + ".";
+  const tagPart = topTags.length > 0 ? ` Main topics: ${topTags}.` : "";
+  const full = base + tagPart;
+  return full.length <= MAX_CONTEXT_CHARS ? full : full.slice(0, MAX_CONTEXT_CHARS - 1) + "\u2026";
 }
 
 function getTopLevelDirectory(notePath: string): string | undefined {

--- a/src/use-cases/sampling-prompt.test.ts
+++ b/src/use-cases/sampling-prompt.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildSamplingPrompt,
+  parseSamplingResponse,
+  SAMPLING_MAX_TOKENS,
+  SAMPLING_TIMEOUT_MS,
+  MAX_CONTEXT_CHARS,
+} from "./sampling-prompt.js";
+import { MAX_SCOPE_CHARS } from "./vault-scope.js";
+import type { VaultEvidence } from "./evidence-hash.js";
+import type { SamplingResponse } from "../domain/interfaces/sampling-provider.js";
+
+const evidence: VaultEvidence = {
+  totalFiles: 5,
+  directories: ["notes", "projects"],
+  tags: ["alpha", "beta"],
+  titles: ["Note A", "Note B"],
+};
+
+describe("buildSamplingPrompt", () => {
+  it("returns a SamplingRequest with correct constants", () => {
+    const req = buildSamplingPrompt(evidence);
+    expect(req.maxTokens).toBe(SAMPLING_MAX_TOKENS);
+    expect(req.timeoutMs).toBe(SAMPLING_TIMEOUT_MS);
+    expect(typeof req.systemPrompt).toBe("string");
+    expect(req.systemPrompt.length).toBeGreaterThan(0);
+  });
+
+  it("encodes evidence as JSON in userMessage", () => {
+    const req = buildSamplingPrompt(evidence);
+    const parsed = JSON.parse(req.userMessage) as unknown;
+    expect(parsed).toMatchObject({
+      totalFiles: 5,
+      directories: ["notes", "projects"],
+      tags: ["alpha", "beta"],
+      titles: ["Note A", "Note B"],
+    });
+  });
+});
+
+describe("parseSamplingResponse", () => {
+  function makeResponse(text: string): SamplingResponse {
+    return { text };
+  }
+
+  it("returns ok=true for valid response", () => {
+    const res = makeResponse(
+      JSON.stringify({ vault_scope: "A scope", vault_context: "A context" })
+    );
+    const result = parseSamplingResponse(res);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.vault_scope).toBe("A scope");
+      expect(result.vault_context).toBe("A context");
+    }
+  });
+
+  it("returns ok=false for non-JSON text", () => {
+    const result = parseSamplingResponse(makeResponse("not json"));
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns ok=false for JSON array", () => {
+    const result = parseSamplingResponse(makeResponse("[]"));
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns ok=false when vault_scope is missing", () => {
+    const result = parseSamplingResponse(
+      makeResponse(JSON.stringify({ vault_context: "ctx" }))
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns ok=false when vault_context is missing", () => {
+    const result = parseSamplingResponse(
+      makeResponse(JSON.stringify({ vault_scope: "scope" }))
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns ok=false when vault_scope is empty string", () => {
+    const result = parseSamplingResponse(
+      makeResponse(JSON.stringify({ vault_scope: "  ", vault_context: "ctx" }))
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns ok=false when vault_scope is not a string", () => {
+    const result = parseSamplingResponse(
+      makeResponse(JSON.stringify({ vault_scope: 42, vault_context: "ctx" }))
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("truncates vault_scope to MAX_SCOPE_CHARS", () => {
+    const longScope = "a".repeat(MAX_SCOPE_CHARS + 50);
+    const result = parseSamplingResponse(
+      makeResponse(JSON.stringify({ vault_scope: longScope, vault_context: "ctx" }))
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.vault_scope.length).toBeLessThanOrEqual(MAX_SCOPE_CHARS);
+    }
+  });
+
+  it("truncates vault_context to MAX_CONTEXT_CHARS", () => {
+    const longCtx = "b".repeat(MAX_CONTEXT_CHARS + 100);
+    const result = parseSamplingResponse(
+      makeResponse(JSON.stringify({ vault_scope: "scope", vault_context: longCtx }))
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.vault_context.length).toBeLessThanOrEqual(MAX_CONTEXT_CHARS);
+    }
+  });
+
+  it("never throws on any input", () => {
+    const inputs = ["", "null", "{}", "undefined", "true", "123"];
+    for (const text of inputs) {
+      expect(() => parseSamplingResponse(makeResponse(text))).not.toThrow();
+    }
+  });
+});

--- a/src/use-cases/sampling-prompt.ts
+++ b/src/use-cases/sampling-prompt.ts
@@ -1,0 +1,84 @@
+import { MAX_SCOPE_CHARS } from "./vault-scope.js";
+import type { VaultEvidence } from "./evidence-hash.js";
+import type { SamplingRequest, SamplingResponse } from "../domain/interfaces/sampling-provider.js";
+
+export const SAMPLING_MAX_TOKENS = 300;
+export const SAMPLING_TIMEOUT_MS = 30_000;
+export const MAX_CONTEXT_CHARS = 500;
+
+const SYSTEM_PROMPT =
+  "You are a vault orientation assistant. Analyze the provided vault evidence and return a JSON object with exactly two fields: " +
+  '"vault_scope" (a short one-line routing hint, max 200 chars) and ' +
+  '"vault_context" (a semantic overview of what the vault is about, max 500 chars). ' +
+  "Return only valid JSON with no markdown fences or extra text.";
+
+export function buildSamplingPrompt(evidence: VaultEvidence): SamplingRequest {
+  const userMessage = JSON.stringify({
+    totalFiles: evidence.totalFiles,
+    directories: evidence.directories,
+    tags: evidence.tags,
+    titles: evidence.titles,
+  });
+
+  return {
+    systemPrompt: SYSTEM_PROMPT,
+    userMessage,
+    maxTokens: SAMPLING_MAX_TOKENS,
+    timeoutMs: SAMPLING_TIMEOUT_MS,
+  };
+}
+
+export type ParseSuccess = {
+  ok: true;
+  vault_scope: string;
+  vault_context: string;
+};
+
+export type ParseFailure = {
+  ok: false;
+  reason: string;
+};
+
+export type ParseResult = ParseSuccess | ParseFailure;
+
+function truncateAtWordBoundary(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const truncated = text.slice(0, maxChars - 1);
+  const lastSpace = truncated.lastIndexOf(" ");
+  if (lastSpace > maxChars * 0.6) {
+    return truncated.slice(0, lastSpace) + "\u2026";
+  }
+  return truncated + "\u2026";
+}
+
+export function parseSamplingResponse(response: SamplingResponse): ParseResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(response.text);
+  } catch {
+    return { ok: false, reason: "response is not valid JSON" };
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return { ok: false, reason: "response is not a JSON object" };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  const rawScope = obj["vault_scope"];
+  const rawContext = obj["vault_context"];
+
+  if (typeof rawScope !== "string" || rawScope.trim().length === 0) {
+    return { ok: false, reason: "vault_scope is missing or empty" };
+  }
+
+  if (typeof rawContext !== "string" || rawContext.trim().length === 0) {
+    return { ok: false, reason: "vault_context is missing or empty" };
+  }
+
+  return {
+    ok: true,
+    vault_scope: truncateAtWordBoundary(rawScope.trim(), MAX_SCOPE_CHARS),
+    vault_context: truncateAtWordBoundary(rawContext.trim(), MAX_CONTEXT_CHARS),
+  };
+}


### PR DESCRIPTION
Implement hybrid vault context generation that keeps deterministic evidence collection but upgrades auto overview output with semantic scope/context via MCP sampling.
What changed
- add ISamplingProvider domain port and NullSamplingProvider fallback
- add sampling prompt construction and response parsing utilities
- add evidence hashing to detect unchanged vault evidence
- refactor OverviewManager to:
- store schema_version: 2
- write vault_scope, vault_context, generation_source, and evidence_hash
- skip regeneration when evidence is unchanged
- fall back to deterministic generation when sampling is unavailable or fails
- add presentation-layer McpSamplingAdapter
- add sampling provider registry for connected MCP clients
- wire lazy sampling provider resolution into index.ts / transport startup
- keep manual mode behavior unchanged
- preserve existing host-visible scope surfaces while sourcing them from the new overview output