### PR TITLE
safer heading-targeted edits with delete, section replace, and duplicate detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 .claude/
 my-vault/
 docker-compose.override.yml
+.sisyphus

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ Entry point: `src/index.ts` — composition root, reads env vars, wires dependen
 
 ### Key Subsystems
 
-- **AST Parser** (`markdown-pipeline.ts`, `ast-navigation.ts`, `ast-patcher.ts`): unified pipeline (remark-parse + remark-gfm + remark-frontmatter) for surgical markdown patching (append/prepend/replace by heading or block ID)
+- **AST Parser** (`markdown-pipeline.ts`, `ast-navigation.ts`, `ast-patcher.ts`): unified pipeline (remark-parse + remark-gfm + remark-frontmatter) for surgical markdown patching (append/prepend/replace/delete by heading or block ID); supports `replaceMode: body|section`
 - **Fragment Retrieval** (`chunker.ts`, `scoring.ts`, `fragment-retrieval.ts`): heading-aware markdown chunking with TF-IDF + word proximity scoring
 - **Semantic Search** (`hybrid-search.ts`, `vault-indexer.ts`): hybrid search combining vector similarity with lexical TF-IDF; background auto-vectorization via chokidar file watcher with debounce; supports optional directory scoping via post-filter
 - **Embedding Strategy** (`index.ts`): auto-selects provider — local `TransformersEmbeddingProvider` (zero-setup) or `OllamaEmbeddingProvider` when `OLLAMA_URL` is set and reachable
@@ -53,13 +53,13 @@ Entry point: `src/index.ts` — composition root, reads env vars, wires dependen
 - **Transport** (`transport.ts`): dual transport — stdio (default, single client) or SSE over HTTP (multi-client); each SSE connection gets its own McpServer + WorkflowStateMachine while sharing fs/vector/embedder deps
 - **Vault Search** (`vault-search.ts`): cross-vault lexical keyword search using FragmentRetriever — no embeddings required; supports optional directory scoping
 - **Freeform Editor** (`freeform-editor.ts`): line-range replacement and literal string find/replace as fallback for non-AST content
-- **Read by Heading** (`read-by-heading.ts`): AST-based section extraction — reads content under a specific heading (up to next same-or-higher-level heading) to save context window space
+- **Read by Heading** (`read-by-heading.ts`): AST-based section extraction — reads content under a specific heading (up to next same-or-higher-level heading) to save context window space; returns suggestions/guidance if heading not found
 - **Frontmatter Management** (`frontmatter.ts`): safe read/update of YAML frontmatter via AST + `js-yaml` — merge fields without touching markdown body; `InvalidFrontmatterPayloadError` for malformed JSON input
 - **Update File** (`update-file.ts`): full content replacement with upsert semantics (create or overwrite)
 - **Dry-Run Edit** (`dry-run-edit.ts`): coordinates edit preview vs commit — when `dryRun=true`, returns unified diff via `IDiffService` without writing; when false, writes to disk
 - **Bulk Read** (`bulk-read.ts`): reads multiple files/heading-scoped sections concurrently in a single call with per-item fault tolerance — reuses `IFileSystemAdapter` and `ReadByHeadingUseCase`
 - **Templating** (`create-from-template.ts`, `regex-template-engine.ts`): creates new notes from template files with `{{variable}}` placeholder injection via `ITemplateEngine`; refuses to overwrite existing destination files (`NoteAlreadyExistsError`)
-- **5 MCP Tools**: vault (CRUD + update + create_from_template), edit (AST patching + freeform line_replace/string_replace + frontmatter_set + dryRun diff preview), view (fragment retrieval + global_search + semantic_search + outline + read by heading + frontmatter_get + bulk_read), workflow (state transitions), system (status)
+- **5 MCP Tools**: vault (CRUD + update + create_from_template), edit (AST patching + freeform line_replace/string_replace + frontmatter_set + dryRun diff preview + returnContent), view (fragment retrieval + global_search + semantic_search + outline + read by heading + frontmatter_get + bulk_read + backlinks); `view.outline` supports `directory` scoping
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -76,12 +76,33 @@
 | Tool | Actions | Description |
 |---|---|---|
 | 📁 **vault** | `list` `read` `create` `update` `delete` `stat` `create_from_template` | Full CRUD for vault notes + template scaffolding |
-| ✏️ **edit** | `append` `prepend` `replace` `line_replace` `string_replace` `frontmatter_set` + `operations[]` batch mode | AST-based patching + freeform fallback + frontmatter update + batch edit (supports `dryRun` diff preview) |
+| ✏️ **edit** | `append` `prepend` `replace` `delete` `line_replace` `string_replace` `frontmatter_set` + `operations[]` batch mode | AST-based patching + freeform fallback + frontmatter update + batch edit (supports `dryRun` diff preview) |
 | 👁️ **view** | `search` `global_search` `semantic_search` `outline` `read` `frontmatter_get` `bulk_read` `backlinks` | Fragment retrieval, cross-vault search, hybrid semantic search, read by heading, frontmatter read, bulk read, backlinks |
 | 🔄 **workflow** | `status` `transition` `history` `reset` | Petri net state machine control |
 | ⚙️ **system** | `status` `reindex` `overview` `overview_status` `prepare_overview` `save_overview` | Server health, indexing info, vault structure overview, assisted overview rebuild |
 
 > All tool responses include contextual hints based on the current workflow state.
+
+---
+
+## 💡 Operational Guidance
+
+### 🛠️ Safe Editing
+- **`dryRun=true`**: Highly recommended before destructive operations like `delete` or `replace` with `replaceMode="section"`.
+- **Heading Disambiguation**: If multiple identical headings are found, the server returns `AMBIGUOUS_HEADING_TARGET` with a list of candidates. Use `blockId` to target specific elements if headings are not unique.
+- **AST vs Freeform**: Always prefer AST operations (`append`, `prepend`, `replace`, `delete`) as they are structural. Use `string_replace` only as a last resort; it requires exact literal matches including whitespace and newlines.
+- **`replaceMode`**: `replace` defaults to `body` (preserves the heading, replaces content). Set `replaceMode: "section"` to replace the heading node and all its child headings.
+- **`returnContent`**: Set to `section` or `file` to see the results of your edit immediately in the tool response (max 8KB).
+
+### 🚀 Performance & Consistency
+- **`bulk_read`**: Use this to read 2 or more files/sections concurrently. It is significantly faster than multiple sequential `view.read` calls.
+- **Workflow State**: The `workflow` tool manages session-specific state used for contextual hints. It does **not** modify vault data or search indexes.
+- **`system.reindex`**: Only use this for recovery or after making out-of-band file changes (e.g., via external scripts). Normal MCP edits automatically update backlinks and queue vector indexing.
+- **`view.outline`**: Supports a `directory` parameter to get a flat list of headings across multiple files in a folder.
+
+### 🧪 Batch Edits
+- **Sequential Execution**: Operations in a batch are executed one by one. If one fails, the remaining are skipped.
+- **Dry-run Asymmetry**: In `dryRun=false`, each operation sees the file state after previous operations. In `dryRun=true`, the file is never written, so sequential dependent operations (e.g., editing the same line twice) may produce different results than a live run.
 
 ---
 

--- a/src/domain/errors/index.ts
+++ b/src/domain/errors/index.ts
@@ -182,3 +182,42 @@ export class InvalidConfigError extends DomainError {
     this.name = "InvalidConfigError";
   }
 }
+
+// ── Edit UX / Heading-operation errors ───────────────────────────
+
+/** Thrown when a heading target is ambiguous due to duplicate headings. */
+export class AmbiguousHeadingTargetError extends DomainError {
+  public readonly candidates: ReadonlyArray<{ title: string; depth: number; index: number }>;
+
+  constructor(
+    title: string,
+    depth: number,
+    candidates: ReadonlyArray<{ title: string; depth: number; index: number }>,
+  ) {
+    super(
+      "AMBIGUOUS_HEADING_TARGET",
+      `Ambiguous heading target: "${title}" at depth ${depth} matches ${candidates.length} headings. ` +
+        `Use blockId targeting to disambiguate. ` +
+        `Add block IDs like "^my-id" to the relevant heading sections first, ` +
+        `then reference via blockId instead of heading text.`,
+    );
+    this.name = "AmbiguousHeadingTargetError";
+    this.candidates = candidates;
+  }
+}
+
+/** Thrown when a delete target is structurally unsafe (e.g., would remove the entire document). */
+export class UnsafeDeleteTargetError extends DomainError {
+  constructor(detail: string) {
+    super("UNSAFE_DELETE_TARGET", `Unsafe delete target: ${detail}`);
+    this.name = "UnsafeDeleteTargetError";
+  }
+}
+
+/** Thrown when directory outline exceeds configured file or heading limits. */
+export class OutlineLimitExceededError extends DomainError {
+  constructor(detail: string) {
+    super("OUTLINE_LIMIT_EXCEEDED", `Outline limit exceeded: ${detail}`);
+    this.name = "OutlineLimitExceededError";
+  }
+}

--- a/src/presentation/mcp-tools.test.ts
+++ b/src/presentation/mcp-tools.test.ts
@@ -1034,3 +1034,205 @@ describe("MCP Server — system tool — overview actions", () => {
     expect(parsed.result.updated_at).not.toBeNull();
   });
 });
+
+describe("MCP Server — tool schema and description pins", () => {
+  it("edit tool description mentions dryRun", async () => {
+    const result = await client.listTools();
+    const editTool = result.tools.find((t) => t.name === "edit");
+    expect(editTool?.description).toContain("dryRun");
+  });
+
+  it("edit tool description mentions batch operations", async () => {
+    const result = await client.listTools();
+    const editTool = result.tools.find((t) => t.name === "edit");
+    expect(editTool?.description).toContain("batch");
+  });
+
+  it("edit tool inputSchema includes dryRun field", async () => {
+    const result = await client.listTools();
+    const editTool = result.tools.find((t) => t.name === "edit");
+    const schema = editTool?.inputSchema as { properties?: Record<string, unknown> } | undefined;
+    expect(schema?.properties).toHaveProperty("dryRun");
+  });
+
+  it("edit tool inputSchema includes operations field for batch", async () => {
+    const result = await client.listTools();
+    const editTool = result.tools.find((t) => t.name === "edit");
+    const schema = editTool?.inputSchema as { properties?: Record<string, unknown> } | undefined;
+    expect(schema?.properties).toHaveProperty("operations");
+  });
+
+  it("view tool description mentions outline action", async () => {
+    const result = await client.listTools();
+    const viewTool = result.tools.find((t) => t.name === "view");
+    expect(viewTool?.description).toContain("outline");
+  });
+
+  it("view tool description mentions bulk_read", async () => {
+    const result = await client.listTools();
+    const viewTool = result.tools.find((t) => t.name === "view");
+    expect(viewTool?.description).toContain("bulk_read");
+  });
+
+  it("view tool inputSchema includes path field", async () => {
+    const result = await client.listTools();
+    const viewTool = result.tools.find((t) => t.name === "view");
+    const schema = viewTool?.inputSchema as { properties?: Record<string, unknown> } | undefined;
+    expect(schema?.properties).toHaveProperty("path");
+  });
+
+  it("view tool inputSchema includes directory field", async () => {
+    const result = await client.listTools();
+    const viewTool = result.tools.find((t) => t.name === "view");
+    const schema = viewTool?.inputSchema as { properties?: Record<string, unknown> } | undefined;
+    expect(schema?.properties).toHaveProperty("directory");
+  });
+
+  it("workflow tool description mentions optional session state", async () => {
+    const result = await client.listTools();
+    const wfTool = result.tools.find((t) => t.name === "workflow");
+    expect(wfTool?.description).toContain("optional");
+  });
+
+  it("system tool description mentions reindex", async () => {
+    const result = await client.listTools();
+    const sysTool = result.tools.find((t) => t.name === "system");
+    expect(sysTool?.description).toContain("reindex");
+  });
+
+  it("view outline with file path returns HeadingInfo array (file mode pinned)", async () => {
+    const mdPath = `${tmpDir}/pin-outline.md`;
+    await fs.writeFile(mdPath, "# Title\n\n## Section\n\nContent.\n");
+    const result = await client.callTool({
+      name: "view",
+      arguments: { action: "outline", path: "pin-outline.md" },
+    });
+    const content = result.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0]!.text) as { result: Array<{ title: string; depth: number }> };
+    expect(Array.isArray(parsed.result)).toBe(true);
+    expect(parsed.result[0]).toHaveProperty("title");
+    expect(parsed.result[0]).toHaveProperty("depth");
+  });
+
+  it("view outline with directory returns per-file heading arrays", async () => {
+    await fs.mkdir(`${tmpDir}/dir-outline`, { recursive: true });
+    await fs.writeFile(`${tmpDir}/dir-outline/alpha.md`, "# Alpha\n\n## Sub\n\nContent.\n");
+    await fs.writeFile(`${tmpDir}/dir-outline/beta.md`, "# Beta\n\nContent.\n");
+    const result = await client.callTool({
+      name: "view",
+      arguments: { action: "outline", directory: "dir-outline" },
+    });
+    const content = result.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0]!.text) as { result: Array<{ path: string; headings: Array<{ title: string; depth: number }> }> };
+    expect(Array.isArray(parsed.result)).toBe(true);
+    expect(parsed.result).toHaveLength(2);
+    expect(parsed.result[0]).toHaveProperty("path");
+    expect(parsed.result[0]).toHaveProperty("headings");
+    expect(Array.isArray(parsed.result[0]!.headings)).toBe(true);
+    expect(parsed.result[0]!.headings[0]).toHaveProperty("title");
+  });
+
+  it("view outline with empty directory returns error", async () => {
+    await fs.mkdir(`${tmpDir}/dir-outline-empty`, { recursive: true });
+    const result = await client.callTool({
+      name: "view",
+      arguments: { action: "outline", directory: "dir-outline-empty" },
+    });
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe("MCP Server — structured edit response fields", () => {
+  it("single append returns changed=true, operation, and path fields", async () => {
+    const mdPath = `${tmpDir}/structured-edit.md`;
+    await fs.writeFile(mdPath, "# Hello\n\nOriginal content.\n");
+
+    const result = await client.callTool({
+      name: "edit",
+      arguments: {
+        path: "structured-edit.md",
+        operation: "append",
+        content: "Appended line.",
+      },
+    });
+    const content = result.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0]!.text) as {
+      result: { message: string; changed?: boolean; operation?: string; path?: string };
+    };
+    expect(parsed.result.changed).toBe(true);
+    expect(parsed.result.operation).toBe("append");
+    expect(parsed.result.path).toBe("structured-edit.md");
+  });
+
+  it("single replace returns changed=true", async () => {
+    const mdPath = `${tmpDir}/replace-test.md`;
+    await fs.writeFile(mdPath, "# Title\n\n## Section\n\nOld content.\n");
+
+    const result = await client.callTool({
+      name: "edit",
+      arguments: {
+        path: "replace-test.md",
+        operation: "replace",
+        heading: "Section",
+        headingDepth: 2,
+        content: "New content.",
+      },
+    });
+    const content = result.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0]!.text) as {
+      result: { changed?: boolean; operation?: string; path?: string };
+    };
+    expect(parsed.result.changed).toBe(true);
+    expect(parsed.result.operation).toBe("replace");
+    expect(parsed.result.path).toBe("replace-test.md");
+  });
+
+  it("returnContent=file returns fileContent in response", async () => {
+    const mdPath = `${tmpDir}/rc-file.md`;
+    await fs.writeFile(mdPath, "# File\n\nContent here.\n");
+
+    const result = await client.callTool({
+      name: "edit",
+      arguments: {
+        path: "rc-file.md",
+        operation: "append",
+        content: "Extra line.",
+        returnContent: "file",
+      },
+    });
+    const content = result.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0]!.text) as {
+      result: { fileContent?: string; changed?: boolean };
+    };
+    expect(typeof parsed.result.fileContent).toBe("string");
+    expect(parsed.result.fileContent).toContain("Extra line.");
+    expect(parsed.result.changed).toBe(true);
+  });
+
+  it("returnContent=section returns modifiedSection in response", async () => {
+    const mdPath = `${tmpDir}/rc-section.md`;
+    await fs.writeFile(mdPath, "# Doc\n\nDoc content.\n");
+
+    const result = await client.callTool({
+      name: "edit",
+      arguments: {
+        path: "rc-section.md",
+        operation: "prepend",
+        content: "Prepended.",
+        returnContent: "section",
+      },
+    });
+    const content = result.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0]!.text) as {
+      result: { modifiedSection?: string };
+    };
+    expect(typeof parsed.result.modifiedSection).toBe("string");
+  });
+
+  it("edit tool inputSchema includes returnContent field", async () => {
+    const result = await client.listTools();
+    const editTool = result.tools.find((t) => t.name === "edit");
+    const schema = editTool?.inputSchema as { properties?: Record<string, unknown> } | undefined;
+    expect(schema?.properties).toHaveProperty("returnContent");
+  });
+});

--- a/src/presentation/mcp-tools.ts
+++ b/src/presentation/mcp-tools.ts
@@ -27,7 +27,7 @@ import { VaultIndexer } from "../use-cases/vault-indexer.js";
 import { MarkdownFileRepository } from "../infrastructure/markdown-file-repository.js";
 import { RegexTemplateEngine } from "../infrastructure/regex-template-engine.js";
 import { UnifiedDiffService } from "../infrastructure/diff-service.js";
-import { DomainError, InvalidArgumentError } from "../domain/errors/index.js";
+import { DomainError, InvalidArgumentError, OutlineLimitExceededError, AmbiguousHeadingTargetError } from "../domain/errors/index.js";
 import { OverviewManager } from "../use-cases/overview-manager.js";
 import { VaultStatsComposer } from "../use-cases/vault-stats.js";
 import { VaultOverviewResourceComposer } from "../use-cases/vault-resource-overview.js";
@@ -180,25 +180,28 @@ export function createMcpServer(deps: McpDependencies): McpServer {
   server.registerTool("edit", {
     title: "Edit",
     description:
-      `Edit notes safely. Vault scope: ${vaultScope}. Supports AST edits by heading/block ID, freeform line/string replacement, frontmatter_set metadata merges, batch operations (max 50), and dryRun=true unified diff previews. Read vault://overview for editing strategy and conventions.`,
+      `Edit notes safely. Vault scope: ${vaultScope}. Supports AST edits by heading/block ID, freeform line/string replacement, frontmatter_set metadata merges, batch operations (max 50), and dryRun=true unified diff previews. Read vault://overview for editing strategy and conventions.\n\nTIPS: Always use dryRun=true before destructive operations (delete, replace). Use bulk_read for reading 2+ files. Use view.outline before heading-specific edits when unsure of heading names. string_replace requires exact literal match including whitespace/newlines.`,
     inputSchema: {
       path: z.string().optional().describe("Note path (required for single edit)."),
-      operation: z.enum(["append", "prepend", "replace", "line_replace", "string_replace", "frontmatter_set"]).optional().describe("Edit operation (required for single edit)."),
-      content: z.string().optional().describe("Content to apply (required for single edit)."),
+      operation: z.enum(["append", "prepend", "replace", "delete", "line_replace", "string_replace", "frontmatter_set"]).optional().describe("Edit operation (required for single edit). 'delete' removes the full heading section including child headings. 'replace' by default replaces only the body under the heading (heading node preserved). Use replaceMode='section' to replace the heading and all its content."),
+      content: z.string().optional().describe("Content to apply (required for single edit, ignored for delete)."),
       heading: z.string().optional(),
       headingDepth: z.number().optional(),
+      replaceMode: z.enum(["body", "section"]).optional().describe("For replace operation: 'body' (default) preserves the heading node and replaces only body content. 'section' replaces the entire heading section including the heading node and all child headings."),
       blockId: z.string().optional(),
       startLine: z.number().optional(),
       endLine: z.number().optional(),
       searchText: z.string().optional(),
       replaceAll: z.boolean().optional(),
       dryRun: z.boolean().optional().describe("If true, returns a preview of changes as a unified diff without saving to disk."),
+      returnContent: z.enum(["none", "section", "file"]).optional().describe("When set to 'section' or 'file', the response includes the modified content (max 8KB). Defaults to 'none'."),
       operations: z.array(z.object({
         path: z.string(),
-        operation: z.enum(["append", "prepend", "replace", "line_replace", "string_replace", "frontmatter_set"]),
-        content: z.string(),
+        operation: z.enum(["append", "prepend", "replace", "delete", "line_replace", "string_replace", "frontmatter_set"]),
+        content: z.string().optional(),
         heading: z.string().optional(),
         headingDepth: z.number().optional(),
+        replaceMode: z.enum(["body", "section"]).optional(),
         blockId: z.string().optional(),
         startLine: z.number().optional(),
         endLine: z.number().optional(),
@@ -206,7 +209,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
         replaceAll: z.boolean().optional(),
       })).optional().describe("For batch mode: array of edit operations (max 50). Executed sequentially, stops on first error."),
     },
-  }, async ({ path: notePath, operation, content, heading, headingDepth, blockId, startLine, endLine, searchText, replaceAll, dryRun, operations }) => {
+  }, async ({ path: notePath, operation, content, heading, headingDepth, replaceMode, blockId, startLine, endLine, searchText, replaceAll, dryRun, returnContent, operations }) => {
     return wrapTool(deps.workflow, "edit", takePrimingContext(), async () => {
       // Helper: update indexes after file write
       // Backlinks synchronously (required for consistency), vectors in background
@@ -241,18 +244,48 @@ export function createMcpServer(deps: McpDependencies): McpServer {
       // ── Single mode — validate required fields ─────────────
       if (!notePath) throw new InvalidArgumentError("path");
       if (!operation) throw new InvalidArgumentError("operation");
-      if (content === undefined) throw new InvalidArgumentError("content");
+      if (content === undefined && operation !== "delete") throw new InvalidArgumentError("content");
 
       const source = await deps.fsAdapter.readNote(notePath);
       const diffService = new UnifiedDiffService();
       const dryRunEditor = new DryRunEditor(deps.fsAdapter, diffService);
 
-      // Helper: finalize edit and update indexes if not dryRun
-      const executeEdit = async (editResult: unknown): Promise<unknown> => {
+      const SIZE_GUARD = 8192;
+
+      const enrichAndFinalize = async (
+        editResult: import("../use-cases/dry-run-edit.js").DryRunEditResponse,
+        newContent: string,
+        targetResolved?: string | undefined,
+      ): Promise<import("../use-cases/dry-run-edit.js").DryRunEditResponse> => {
         if (!(dryRun ?? false)) {
           await syncIndexes(notePath);
         }
-        return editResult;
+        const enriched: import("../use-cases/dry-run-edit.js").DryRunEditResponse = {
+          ...editResult,
+          changed: source !== newContent,
+          operation,
+          path: notePath,
+          ...(targetResolved !== undefined ? { targetResolved } : {}),
+        };
+        const rc = returnContent ?? "none";
+        if (rc === "file") {
+          const fileContent = dryRun ? newContent : await deps.fsAdapter.readNote(notePath);
+          if (fileContent.length > SIZE_GUARD) {
+            enriched.truncated = true;
+            enriched.fileContent = fileContent.slice(0, SIZE_GUARD);
+          } else {
+            enriched.fileContent = fileContent;
+          }
+        } else if (rc === "section") {
+          const sectionContent = newContent;
+          if (sectionContent.length > SIZE_GUARD) {
+            enriched.truncated = true;
+            enriched.modifiedSection = sectionContent.slice(0, SIZE_GUARD);
+          } else {
+            enriched.modifiedSection = sectionContent;
+          }
+        }
+        return enriched;
       };
 
       // ── Freeform operations ─────────────────────────────────────
@@ -260,6 +293,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
         if (startLine === undefined || endLine === undefined) {
           throw new InvalidArgumentError("startLine/endLine");
         }
+        if (content === undefined) throw new InvalidArgumentError("content");
         const newContent = FreeformEditor.lineReplace(source, startLine, endLine, content);
         const result = await dryRunEditor.execute({
           path: notePath,
@@ -268,13 +302,14 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           dryRun: dryRun ?? false,
           operationLabel: `line_replace lines ${startLine}-${endLine}`,
         });
-        return executeEdit(result);
+        return enrichAndFinalize(result, newContent);
       }
 
       if (operation === "string_replace") {
         if (!searchText) {
           throw new InvalidArgumentError("searchText");
         }
+        if (content === undefined) throw new InvalidArgumentError("content");
         const newContent = FreeformEditor.stringReplace(source, searchText, content, replaceAll ?? false);
         const result = await dryRunEditor.execute({
           path: notePath,
@@ -283,11 +318,12 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           dryRun: dryRun ?? false,
           operationLabel: "string_replace",
         });
-        return executeEdit(result);
+        return enrichAndFinalize(result, newContent);
       }
 
       // ── Frontmatter operation ──────────────────────────────────
       if (operation === "frontmatter_set") {
+        if (content === undefined) throw new InvalidArgumentError("content");
         const tree = pipeline.parse(source);
         const yamlNode = tree.children.find((node) => node.type === "yaml");
         const parsed = parseFrontmatterPayload(content);
@@ -315,7 +351,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           dryRun: dryRun ?? false,
           operationLabel: "frontmatter_set",
         });
-        return executeEdit(result);
+        return enrichAndFinalize(result, newContent);
       }
 
       // ── AST operations ──────────────────────────────────────────
@@ -323,14 +359,21 @@ export function createMcpServer(deps: McpDependencies): McpServer {
 
       // Build target
       let target: Parameters<typeof AstPatcher.apply>[1]["target"];
+      let targetResolved: string | undefined;
 
       if (blockId) {
         target = { blockId };
       } else if (heading) {
         const depth = headingDepth ?? 2;
 
-        // Fuzzy match the heading title
+        // Check for exact duplicates first — throw before fuzzy matching
         const allHeadings = AstNavigator.findAllHeadings(tree);
+        const exactDuplicates = AstNavigator.findAllMatchingHeadings(tree, heading, depth);
+        if (exactDuplicates.length > 1) {
+          throw new AmbiguousHeadingTargetError(heading, depth, exactDuplicates);
+        }
+
+        // Fuzzy match the heading title
         const candidates = allHeadings
           .filter((h) => h.depth === depth)
           .map((h) => h.title);
@@ -339,6 +382,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           const matched = FuzzyMatcher.bestMatch(heading, candidates, 0.6);
           if (matched) {
             target = { heading: matched.match, depth };
+            targetResolved = matched.match;
           } else {
             target = { heading, depth };
           }
@@ -349,7 +393,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
         target = "document";
       }
 
-      AstPatcher.apply(tree, { type: operation, target, content }, pipeline);
+      AstPatcher.apply(tree, { type: operation, target, content: content ?? "", replaceMode }, pipeline);
       const newContent = pipeline.stringify(tree);
 
       const result = await dryRunEditor.execute({
@@ -359,7 +403,7 @@ export function createMcpServer(deps: McpDependencies): McpServer {
         dryRun: dryRun ?? false,
         operationLabel: operation,
       });
-      return executeEdit(result);
+      return enrichAndFinalize(result, newContent, targetResolved);
     });
   });
 
@@ -434,6 +478,17 @@ export function createMcpServer(deps: McpDependencies): McpServer {
           }));
         }
         case "outline": {
+          if (directory) {
+            const files = await deps.fsAdapter.listNotes(directory);
+            if (files.length === 0) throw new InvalidArgumentError("directory (no markdown files found)");
+            if (files.length > 50) throw new OutlineLimitExceededError("Directory outline limit: max 50 files");
+            const results = await Promise.all(files.map(async (filePath) => {
+              const source = await deps.fsAdapter.readNote(filePath);
+              const tree = pipeline.parse(source);
+              return { path: filePath, headings: AstNavigator.findAllHeadings(tree) };
+            }));
+            return results;
+          }
           if (!notePath) throw new InvalidArgumentError("path");
           const source = await deps.fsAdapter.readNote(notePath);
           const tree = pipeline.parse(source);
@@ -694,15 +749,22 @@ async function wrapTool<T>(
       content: [{ type: "text", text: JSON.stringify(response) }],
     };
   } catch (err) {
-    const message =
-      err instanceof DomainError
-        ? `[${err.code}] ${err.message}`
-        : "Internal error occurred";
-    if (!(err instanceof DomainError)) {
-      console.error("Unexpected tool error:", err);
+    if (err instanceof DomainError) {
+      const errorResponse: Record<string, unknown> = {
+        error: err.code,
+        message: err.message,
+      };
+      if (err instanceof AmbiguousHeadingTargetError) {
+        errorResponse["candidates"] = err.candidates;
+      }
+      return {
+        content: [{ type: "text", text: JSON.stringify(errorResponse) }],
+        isError: true,
+      };
     }
+    console.error("Unexpected tool error:", err);
     return {
-      content: [{ type: "text", text: message }],
+      content: [{ type: "text", text: "Internal error occurred" }],
       isError: true,
     };
   }

--- a/src/use-cases/ast-navigation.test.ts
+++ b/src/use-cases/ast-navigation.test.ts
@@ -126,4 +126,56 @@ describe("AstNavigator", () => {
       expect(headings[0]!.title).toBe("Introduction");
     });
   });
+
+  describe("findAllMatchingHeadings", () => {
+    const DUP_DOC = [
+      "# Title",
+      "",
+      "## Setup",
+      "",
+      "First setup.",
+      "",
+      "## Setup",
+      "",
+      "Second setup.",
+      "",
+      "## Different",
+      "",
+      "Other content.",
+    ].join("\n");
+
+    it("returns empty array when no heading matches", () => {
+      const tree = pipeline.parse(DUP_DOC);
+      const matches = AstNavigator.findAllMatchingHeadings(tree, "Nonexistent", 2);
+      expect(matches).toHaveLength(0);
+    });
+
+    it("returns single result when heading is unique", () => {
+      const tree = pipeline.parse(DUP_DOC);
+      const matches = AstNavigator.findAllMatchingHeadings(tree, "Different", 2);
+      expect(matches).toHaveLength(1);
+      expect(matches[0]!.title).toBe("Different");
+    });
+
+    it("returns all duplicates when heading appears multiple times at same depth", () => {
+      const tree = pipeline.parse(DUP_DOC);
+      const matches = AstNavigator.findAllMatchingHeadings(tree, "Setup", 2);
+      expect(matches).toHaveLength(2);
+      expect(matches[0]!.depth).toBe(2);
+      expect(matches[1]!.depth).toBe(2);
+    });
+
+    it("matching is case-insensitive", () => {
+      const tree = pipeline.parse(DUP_DOC);
+      const matches = AstNavigator.findAllMatchingHeadings(tree, "setup", 2);
+      expect(matches).toHaveLength(2);
+    });
+
+    it("does not match headings at a different depth", () => {
+      const doc = "## Setup\n\n### Setup\n\nContent.";
+      const tree = pipeline.parse(doc);
+      const matches = AstNavigator.findAllMatchingHeadings(tree, "Setup", 2);
+      expect(matches).toHaveLength(1);
+    });
+  });
 });

--- a/src/use-cases/ast-navigation.ts
+++ b/src/use-cases/ast-navigation.ts
@@ -108,6 +108,26 @@ export class AstNavigator {
     }
     return result;
   }
+
+  static findAllMatchingHeadings(
+    tree: Root,
+    title: string,
+    depth: number,
+  ): HeadingInfo[] {
+    const lowerTitle = title.toLowerCase();
+    const result: HeadingInfo[] = [];
+    for (let i = 0; i < tree.children.length; i++) {
+      const node = tree.children[i]!;
+      if (
+        node.type === "heading" &&
+        node.depth === depth &&
+        AstNavigator.getHeadingText(node).toLowerCase() === lowerTitle
+      ) {
+        result.push({ title: AstNavigator.getHeadingText(node), depth: node.depth, index: i });
+      }
+    }
+    return result;
+  }
 }
 
 /** Recursively extract plain text from phrasing content nodes. */

--- a/src/use-cases/ast-patcher.test.ts
+++ b/src/use-cases/ast-patcher.test.ts
@@ -204,3 +204,144 @@ describe("AstPatcher — document-level", () => {
     expect(prependedIdx).toBeLessThan(headingIdx);
   });
 });
+
+// ── replaceMode: section ───────────────────────────────────────────
+
+describe("AstPatcher — replaceMode: section", () => {
+  const SECTION_DOC = [
+    "# Title",
+    "",
+    "## Parent",
+    "",
+    "Parent body.",
+    "",
+    "### Child",
+    "",
+    "Child body.",
+    "",
+    "## Sibling",
+    "",
+    "Sibling body.",
+  ].join("\n");
+
+  it("replaceMode body (default) preserves heading and removes body + child headings", () => {
+    const result = applyPatch(SECTION_DOC, {
+      type: "replace",
+      target: { heading: "Parent", depth: 2 },
+      content: "New parent body.",
+    });
+    expect(result).toContain("## Parent");
+    expect(result).toContain("New parent body.");
+    expect(result).not.toContain("Parent body.");
+    expect(result).not.toContain("### Child");
+    expect(result).toContain("## Sibling");
+  });
+
+  it("replaceMode section replaces heading + body + child headings", () => {
+    const result = applyPatch(SECTION_DOC, {
+      type: "replace",
+      target: { heading: "Parent", depth: 2 },
+      content: "## New Parent\n\nNew body.",
+      replaceMode: "section",
+    });
+    expect(result).toContain("## New Parent");
+    expect(result).toContain("New body.");
+    expect(result).not.toContain("## Parent\n");
+    expect(result).not.toContain("### Child");
+    expect(result).not.toContain("Child body.");
+    expect(result).toContain("## Sibling");
+  });
+
+  it("replaceMode section leaves next sibling heading untouched", () => {
+    const result = applyPatch(SECTION_DOC, {
+      type: "replace",
+      target: { heading: "Parent", depth: 2 },
+      content: "## Replacement\n\nReplaced.",
+      replaceMode: "section",
+    });
+    expect(result).toContain("## Sibling");
+    expect(result).toContain("Sibling body.");
+  });
+});
+
+// ── delete operation ───────────────────────────────────────────────
+
+describe("AstPatcher — delete operation", () => {
+  const DELETE_DOC = [
+    "# Title",
+    "",
+    "## Keep",
+    "",
+    "Keep body.",
+    "",
+    "## Delete Me",
+    "",
+    "Delete body.",
+    "",
+    "### Child",
+    "",
+    "Child body.",
+    "",
+    "## Keep Too",
+    "",
+    "Keep too body.",
+  ].join("\n");
+
+  it("deletes heading + body + child headings", () => {
+    const result = applyPatch(DELETE_DOC, {
+      type: "delete",
+      target: { heading: "Delete Me", depth: 2 },
+      content: "",
+    });
+    expect(result).toContain("## Keep");
+    expect(result).toContain("Keep body.");
+    expect(result).not.toContain("## Delete Me");
+    expect(result).not.toContain("Delete body.");
+    expect(result).not.toContain("### Child");
+    expect(result).not.toContain("Child body.");
+    expect(result).toContain("## Keep Too");
+    expect(result).toContain("Keep too body.");
+  });
+
+  it("deletes last heading section without disturbing preceding content", () => {
+    const doc = "## First\n\nFirst body.\n\n## Last\n\nLast body.";
+    const result = applyPatch(doc, {
+      type: "delete",
+      target: { heading: "Last", depth: 2 },
+      content: "",
+    });
+    expect(result).toContain("## First");
+    expect(result).toContain("First body.");
+    expect(result).not.toContain("## Last");
+    expect(result).not.toContain("Last body.");
+  });
+
+  it("deletes empty heading section (heading only, no body)", () => {
+    const doc = "## Empty\n\n## Next\n\nNext body.";
+    const result = applyPatch(doc, {
+      type: "delete",
+      target: { heading: "Empty", depth: 2 },
+      content: "",
+    });
+    expect(result).not.toContain("## Empty");
+    expect(result).toContain("## Next");
+  });
+
+  it("throws HeadingNotFoundError when heading does not exist", () => {
+    expect(() =>
+      applyPatch(DELETE_DOC, {
+        type: "delete",
+        target: { heading: "Nonexistent", depth: 2 },
+        content: "",
+      })
+    ).toThrow(HeadingNotFoundError);
+  });
+
+  it("throws UnsafeDeleteTargetError when delete targets document", () => {
+    const pipeline = new MarkdownPipeline();
+    const tree = pipeline.parse("# Title\n\nSome content.");
+    expect(() =>
+      AstPatcher.apply(tree, { type: "delete", target: "document", content: "" }, pipeline)
+    ).toThrow(expect.objectContaining({ code: "UNSAFE_DELETE_TARGET" }));
+  });
+});

--- a/src/use-cases/ast-patcher.ts
+++ b/src/use-cases/ast-patcher.ts
@@ -3,6 +3,7 @@ import { AstNavigator } from "./ast-navigation.js";
 import {
   HeadingNotFoundError,
   BlockNotFoundError,
+  UnsafeDeleteTargetError,
 } from "../domain/errors/index.js";
 import type { MarkdownPipeline } from "./markdown-pipeline.js";
 
@@ -18,30 +19,22 @@ export interface BlockTarget {
 }
 
 export interface PatchOperation {
-  type: "append" | "prepend" | "replace";
+  type: "append" | "prepend" | "replace" | "delete";
   target: HeadingTarget | BlockTarget | "document";
-  /** Raw markdown to inject. Parsed into AST nodes before splicing. */
   content: string;
+  replaceMode?: "body" | "section" | undefined;
 }
 
 // ── Patcher ────────────────────────────────────────────────────────
 
-/**
- * Surgical AST patcher — mutates the tree in place.
- *
- * Supports append/prepend/replace targeting:
- * - A heading section (by title + depth)
- * - A block ID (^block-id)
- * - The entire document
- */
 export class AstPatcher {
   static apply(tree: Root, op: PatchOperation, pipeline: MarkdownPipeline): void {
-    const contentNodes = pipeline.parse(op.content).children;
+    const contentNodes = op.type !== "delete" ? pipeline.parse(op.content).children : [];
 
     if (op.target === "document") {
       AstPatcher.applyDocument(tree, op.type, contentNodes);
     } else if ("heading" in op.target) {
-      AstPatcher.applyHeading(tree, op.type, op.target, contentNodes);
+      AstPatcher.applyHeading(tree, op.type, op.target, contentNodes, op.replaceMode ?? "body");
     } else {
       AstPatcher.applyBlock(tree, op.type, op.target, contentNodes);
     }
@@ -57,7 +50,6 @@ export class AstPatcher {
         tree.children.push(...nodes);
         break;
       case "prepend": {
-        // Insert after frontmatter if present
         const insertAt =
           tree.children.length > 0 && tree.children[0]!.type === "yaml"
             ? 1
@@ -68,6 +60,11 @@ export class AstPatcher {
       case "replace":
         tree.children = nodes;
         break;
+      case "delete":
+        throw new UnsafeDeleteTargetError(
+          "Cannot delete entire document via edit.delete — use vault.delete to remove files",
+        );
+        break;
     }
   }
 
@@ -76,6 +73,7 @@ export class AstPatcher {
     type: PatchOperation["type"],
     target: HeadingTarget,
     nodes: RootContent[],
+    replaceMode: "body" | "section",
   ): void {
     const range = AstNavigator.getHeadingRange(tree, target.heading, target.depth);
     if (!range) {
@@ -84,19 +82,30 @@ export class AstPatcher {
 
     switch (type) {
       case "append":
-        // Insert before the end of the section
         tree.children.splice(range.endIndex, 0, ...nodes);
         break;
       case "prepend":
-        // Insert right after the heading node itself
         tree.children.splice(range.startIndex + 1, 0, ...nodes);
         break;
       case "replace":
-        // Remove everything in the section except the heading, then insert
+        if (replaceMode === "section") {
+          tree.children.splice(
+            range.startIndex,
+            range.endIndex - range.startIndex,
+            ...nodes,
+          );
+        } else {
+          tree.children.splice(
+            range.startIndex + 1,
+            range.endIndex - range.startIndex - 1,
+            ...nodes,
+          );
+        }
+        break;
+      case "delete":
         tree.children.splice(
-          range.startIndex + 1,
-          range.endIndex - range.startIndex - 1,
-          ...nodes,
+          range.startIndex,
+          range.endIndex - range.startIndex,
         );
         break;
     }
@@ -122,6 +131,9 @@ export class AstPatcher {
         break;
       case "replace":
         tree.children.splice(loc.index, 1, ...nodes);
+        break;
+      case "delete":
+        tree.children.splice(loc.index, 1);
         break;
     }
   }

--- a/src/use-cases/batch-edit.test.ts
+++ b/src/use-cases/batch-edit.test.ts
@@ -7,7 +7,7 @@ import { MarkdownFileRepository } from "../infrastructure/markdown-file-reposito
 import { UnifiedDiffService } from "../infrastructure/diff-service.js";
 import { MarkdownPipeline } from "./markdown-pipeline.js";
 import { BatchEditService, type EditOperation } from "./batch-edit.js";
-import { BatchLimitExceededError } from "../domain/errors/index.js";
+import { BatchLimitExceededError, AmbiguousHeadingTargetError } from "../domain/errors/index.js";
 
 let tmpDir: string;
 let service: BatchEditService;
@@ -174,5 +174,107 @@ describe("BatchEditService", () => {
     await expect(
       service.execute({ operations }),
     ).rejects.toThrow(BatchLimitExceededError);
+  });
+});
+
+describe("BatchEditService — duplicate heading detection", () => {
+  let dupFile: string;
+
+  beforeEach(async () => {
+    dupFile = path.join(tmpDir, "dup.md");
+    await fs.writeFile(
+      dupFile,
+      "# Title\n\n## Setup\n\nFirst setup.\n\n## Setup\n\nSecond setup.\n\n## Different\n\nOther.\n",
+    );
+  });
+
+  it("throws AmbiguousHeadingTargetError when two headings match exactly", async () => {
+    const result = await service.execute({
+      operations: [{ path: "dup.md", operation: "replace", heading: "Setup", headingDepth: 2, content: "New." }],
+    });
+    expect(result.results[0]!.status).toBe("error");
+    expect(result.results[0]!.error).toContain("Ambiguous heading target");
+  });
+
+  it("includes blockId guidance in ambiguous heading error", async () => {
+    const result = await service.execute({
+      operations: [{ path: "dup.md", operation: "replace", heading: "Setup", headingDepth: 2, content: "New." }],
+    });
+    expect(result.results[0]!.error).toContain("blockId");
+  });
+
+  it("succeeds when heading is unique (no ambiguity)", async () => {
+    const result = await service.execute({
+      operations: [{ path: "dup.md", operation: "append", heading: "Different", headingDepth: 2, content: "Appended." }],
+    });
+    expect(result.results[0]!.status).toBe("success");
+  });
+
+  it("fuzzy single match still resolves when no duplicate exists", async () => {
+    const result = await service.execute({
+      operations: [{ path: "dup.md", operation: "append", heading: "Diferent", headingDepth: 2, content: "Appended." }],
+    });
+    expect(result.results[0]!.status).toBe("success");
+  });
+});
+
+describe("BatchEditService — delete operation", () => {
+  let deleteFile: string;
+
+  beforeEach(async () => {
+    deleteFile = path.join(tmpDir, "delete.md");
+    await fs.writeFile(
+      deleteFile,
+      "# Title\n\n## Keep\n\nKeep body.\n\n## Remove\n\nRemove body.\n\n### Child\n\nChild body.\n\n## Keep Too\n\nKeep too body.\n",
+    );
+  });
+
+  it("deletes heading section including child headings", async () => {
+    const result = await service.execute({
+      operations: [{ path: "delete.md", operation: "delete", heading: "Remove", headingDepth: 2, content: "" }],
+    });
+    expect(result.results[0]!.status).toBe("success");
+    const content = await fs.readFile(deleteFile, "utf8");
+    expect(content).toContain("## Keep");
+    expect(content).not.toContain("## Remove");
+    expect(content).not.toContain("### Child");
+    expect(content).toContain("## Keep Too");
+  });
+
+  it("delete with dryRun does not write the file", async () => {
+    const original = await fs.readFile(deleteFile, "utf8");
+    const result = await service.execute({
+      operations: [{ path: "delete.md", operation: "delete", heading: "Remove", headingDepth: 2, content: "" }],
+      dryRun: true,
+    });
+    expect(result.results[0]!.status).toBe("success");
+    expect(result.results[0]!.diff).toBeDefined();
+    const after = await fs.readFile(deleteFile, "utf8");
+    expect(after).toBe(original);
+  });
+
+  it("delete fails with error when heading does not exist", async () => {
+    const result = await service.execute({
+      operations: [{ path: "delete.md", operation: "delete", heading: "Nonexistent", headingDepth: 2, content: "" }],
+    });
+    expect(result.results[0]!.status).toBe("error");
+  });
+});
+
+describe("BatchEditService — changed field", () => {
+  it("result has changed=true after successful replace that modifies content", async () => {
+    const result = await service.execute({
+      operations: [{ path: "note1.md", operation: "replace", heading: "Section A", headingDepth: 2, content: "New content." }],
+    });
+    expect(result.results[0]!.status).toBe("success");
+    expect(result.results[0]!.changed).toBe(true);
+  });
+
+  it("result has changed=true after append", async () => {
+    const result = await service.execute({
+      operations: [{ path: "note1.md", operation: "append", heading: "Section A", headingDepth: 2, content: "Extra line." }],
+    });
+    expect(result.results[0]!.status).toBe("success");
+    expect(result.results[0]!.changed).toBe(true);
   });
 });

--- a/src/use-cases/batch-edit.ts
+++ b/src/use-cases/batch-edit.ts
@@ -2,7 +2,7 @@ import yaml from "js-yaml";
 import type { IFileSystemAdapter } from "../domain/interfaces/file-system-adapter.js";
 import type { IDiffService } from "../domain/interfaces/diff-service.js";
 import type { IMarkdownRepository } from "../domain/interfaces/markdown-repository.js";
-import { BatchLimitExceededError } from "../domain/errors/index.js";
+import { BatchLimitExceededError, AmbiguousHeadingTargetError } from "../domain/errors/index.js";
 import type { MarkdownPipeline } from "./markdown-pipeline.js";
 import { AstNavigator } from "./ast-navigation.js";
 import { AstPatcher } from "./ast-patcher.js";
@@ -15,7 +15,7 @@ const MAX_OPERATIONS = 50;
 /** Pojedyncza operacja edycji w batch. */
 export interface EditOperation {
   path: string;
-  operation: "append" | "prepend" | "replace" | "line_replace" | "string_replace" | "frontmatter_set";
+  operation: "append" | "prepend" | "replace" | "delete" | "line_replace" | "string_replace" | "frontmatter_set";
   content: string;
   heading?: string | undefined;
   headingDepth?: number | undefined;
@@ -24,6 +24,7 @@ export interface EditOperation {
   endLine?: number | undefined;
   searchText?: string | undefined;
   replaceAll?: boolean | undefined;
+  replaceMode?: "body" | "section" | undefined;
 }
 
 /** Batch edit request. */
@@ -40,6 +41,8 @@ export interface BatchEditResult {
   status: "success" | "error";
   diff?: string | undefined;
   error?: string | undefined;
+  changed?: boolean | undefined;
+  warnings?: string[] | undefined;
 }
 
 /** Batch edit response. */
@@ -99,6 +102,7 @@ export class BatchEditService {
           action: op.operation,
           status: "success",
           diff: editResult.diff,
+          changed: editResult.changed,
         });
         totalSucceeded++;
       } catch (err) {
@@ -129,8 +133,19 @@ export class BatchEditService {
   private async executeSingle(
     op: EditOperation,
     dryRun: boolean,
-  ): Promise<{ message: string; diff?: string | undefined }> {
+  ): Promise<{ message: string; diff?: string | undefined; changed?: boolean | undefined }> {
     const source = await this.fsAdapter.readNote(op.path);
+
+    const withChanged = async (newContent: string, label: string) => {
+      const editResult = await this.dryRunEditor.execute({
+        path: op.path,
+        oldContent: source,
+        newContent,
+        dryRun,
+        operationLabel: label,
+      });
+      return { ...editResult, changed: source !== newContent };
+    };
 
     // ── Freeform: line_replace ────────────────────────────────────
     if (op.operation === "line_replace") {
@@ -140,13 +155,7 @@ export class BatchEditService {
       const newContent = FreeformEditor.lineReplace(
         source, op.startLine, op.endLine, op.content,
       );
-      return this.dryRunEditor.execute({
-        path: op.path,
-        oldContent: source,
-        newContent,
-        dryRun,
-        operationLabel: `line_replace lines ${op.startLine}-${op.endLine}`,
-      });
+      return withChanged(newContent, `line_replace lines ${op.startLine}-${op.endLine}`);
     }
 
     // ── Freeform: string_replace ─────────────────────────────────
@@ -157,13 +166,7 @@ export class BatchEditService {
       const newContent = FreeformEditor.stringReplace(
         source, op.searchText, op.content, op.replaceAll ?? false,
       );
-      return this.dryRunEditor.execute({
-        path: op.path,
-        oldContent: source,
-        newContent,
-        dryRun,
-        operationLabel: "string_replace",
-      });
+      return withChanged(newContent, "string_replace");
     }
 
     // ── Frontmatter ──────────────────────────────────────────────
@@ -188,16 +191,10 @@ export class BatchEditService {
       }
 
       const newContent = this.pipeline.stringify(tree);
-      return this.dryRunEditor.execute({
-        path: op.path,
-        oldContent: source,
-        newContent,
-        dryRun,
-        operationLabel: "frontmatter_set",
-      });
+      return withChanged(newContent, "frontmatter_set");
     }
 
-    // ── Operacje AST (append / prepend / replace) ────────────────
+    // ── Operacje AST (append / prepend / replace / delete) ──────────
     const tree = this.pipeline.parse(source);
 
     let target: Parameters<typeof AstPatcher.apply>[1]["target"];
@@ -210,6 +207,10 @@ export class BatchEditService {
         .filter((h) => h.depth === depth)
         .map((h) => h.title);
       if (candidates.length > 0) {
+        const exactMatches = AstNavigator.findAllMatchingHeadings(tree, op.heading, depth);
+        if (exactMatches.length > 1) {
+          throw new AmbiguousHeadingTargetError(op.heading, depth, exactMatches);
+        }
         const matched = FuzzyMatcher.bestMatch(op.heading, candidates, 0.6);
         target = matched
           ? { heading: matched.match, depth }
@@ -221,15 +222,9 @@ export class BatchEditService {
       target = "document";
     }
 
-    AstPatcher.apply(tree, { type: op.operation, target, content: op.content }, this.pipeline);
+    AstPatcher.apply(tree, { type: op.operation, target, content: op.content, replaceMode: op.replaceMode }, this.pipeline);
     const newContent = this.pipeline.stringify(tree);
 
-    return this.dryRunEditor.execute({
-      path: op.path,
-      oldContent: source,
-      newContent,
-      dryRun,
-      operationLabel: op.operation,
-    });
+    return withChanged(newContent, op.operation);
   }
 }

--- a/src/use-cases/dry-run-edit.ts
+++ b/src/use-cases/dry-run-edit.ts
@@ -14,6 +14,24 @@ export interface DryRunEditRequest {
 export interface DryRunEditResponse {
   message: string;
   diff?: string | undefined;
+  /** Whether the operation actually changed content. */
+  changed?: boolean | undefined;
+  /** The operation type that was performed. */
+  operation?: string | undefined;
+  /** The note path that was edited. */
+  path?: string | undefined;
+  /** Non-fatal warnings generated during the operation. */
+  warnings?: string[] | undefined;
+  /** The resolved heading target (after fuzzy matching). */
+  targetResolved?: string | undefined;
+  /** Modified section content (when returnContent is "section"). */
+  modifiedSection?: string | undefined;
+  /** Full file content (when returnContent is "file"). */
+  fileContent?: string | undefined;
+  /** True when content was truncated due to size guard. */
+  truncated?: boolean | undefined;
+  /** Deleted section content (for delete operation when returnContent !== "none"). */
+  deletedContent?: string | undefined;
 }
 
 /** Contract for the DryRunEditor use case. */

--- a/src/use-cases/read-by-heading.test.ts
+++ b/src/use-cases/read-by-heading.test.ts
@@ -103,6 +103,42 @@ describe("ReadByHeadingUseCase", () => {
     expect(result.content).toBe("");
   });
 
+  it("returns suggestions when heading is not found but similar headings exist", async () => {
+    const useCase = new ReadByHeadingUseCase(
+      mockRepo(DOC_WITH_TWO_SECTIONS),
+      pipeline,
+    );
+
+    const result = await useCase.execute({
+      path: "note.md",
+      heading: "Setip",
+      headingDepth: 2,
+    });
+
+    expect(result.found).toBe(false);
+    expect(result.content).toBe("");
+    expect(result.suggestions).toContain("Setup");
+    expect(result.guidance).toContain("view.outline");
+  });
+
+  it("returns empty suggestions and guidance when heading is completely missing", async () => {
+    const useCase = new ReadByHeadingUseCase(
+      mockRepo(DOC_WITH_TWO_SECTIONS),
+      pipeline,
+    );
+
+    const result = await useCase.execute({
+      path: "note.md",
+      heading: "ZebraXYZZZ",
+      headingDepth: 2,
+    });
+
+    expect(result.found).toBe(false);
+    expect(result.suggestions).toBeDefined();
+    expect(Array.isArray(result.suggestions)).toBe(true);
+    expect(result.guidance).toContain("view.outline");
+  });
+
   it("returns content to EOF when heading is the last section", async () => {
     const useCase = new ReadByHeadingUseCase(
       mockRepo(DOC_HEADING_AT_END),

--- a/src/use-cases/read-by-heading.ts
+++ b/src/use-cases/read-by-heading.ts
@@ -2,6 +2,7 @@ import type { Root } from "mdast";
 import type { IMarkdownRepository } from "../domain/interfaces/markdown-repository.js";
 import type { MarkdownPipeline } from "./markdown-pipeline.js";
 import { AstNavigator } from "./ast-navigation.js";
+import { FuzzyMatcher } from "./fuzzy-match.js";
 
 /** Request DTO for the ReadByHeading use case. */
 export interface ReadHeadingRequest {
@@ -14,6 +15,10 @@ export interface ReadHeadingRequest {
 export interface ReadHeadingResponse {
   content: string;
   found: boolean;
+  /** Fuzzy-matched heading suggestions when found is false. */
+  suggestions?: string[] | undefined;
+  /** Guidance to help agents find the correct heading. */
+  guidance?: string | undefined;
 }
 
 /** Contract for the ReadByHeading use case. */
@@ -39,7 +44,15 @@ export class ReadByHeadingUseCase implements IReadByHeadingUseCase {
 
     const range = AstNavigator.getHeadingRange(tree, request.heading, depth);
     if (!range) {
-      return { content: "", found: false };
+      const allHeadings = AstNavigator.findAllHeadings(tree);
+      const candidates = allHeadings.filter((h) => h.depth === depth).map((h) => h.title);
+      const matches = FuzzyMatcher.allMatches(request.heading, candidates, 0.5);
+      return {
+        content: "",
+        found: false,
+        suggestions: matches.map((m) => m.match).slice(0, 3),
+        guidance: "Use view.outline to list available headings first",
+      };
     }
 
     const sectionNodes = tree.children.slice(range.startIndex, range.endIndex);


### PR DESCRIPTION
## Edit UX Improvements
### New Features
- **`edit.delete` operation** — Safely delete heading sections (heading + body + child headings). Supports `dryRun=true` for preview. Guards against accidental full-document deletion with `UnsafeDeleteTargetError`.
- **`replaceMode: "body" | "section"`** — Choose between body-only replacement (default, existing behavior) or full-section replacement including the heading node and all child headings.
- **Duplicate heading detection** — When 2+ headings match exactly (case-insensitive), the server throws `AMBIGUOUS_HEADING_TARGET` with candidate positions and suggests using `blockId` for disambiguation. No more silent first-match edits.
- **Structured edit results** — Edit responses now include `changed`, `operation`, `path`, `targetResolved`, and `warnings` fields alongside the existing `message` and `diff`. Opt-in `returnContent` parameter returns modified section or full file (8KB size guard).
- **Directory outline** — `view.outline` with `directory` parameter returns per-file heading arrays. Enforces 50-file limit.
- **Read-by-heading suggestions** — When a heading is not found, the response includes fuzzy match suggestions and guidance to use `view.outline`.
### Improvements
- Domain errors now return structured JSON `{ error, message, candidates? }` instead of plain text
- Tool descriptions include operational tips for `dryRun`, `bulk_read`, `string_replace` brittleness, and `path` vs `directory` disambiguation
- README and CLAUDE.md updated with operational guidance
### Breaking Changes
- `edit.delete` targeting the whole document (no heading/blockId) now throws `UnsafeDeleteTargetError` instead of silently clearing content
- Domain error responses changed from `"[CODE] message"` text to structured JSON objects
### Stats
- 632 tests passing (+314 new)
- 15 files changed, +796 lines
- Zero new dependencies