### PR TITLE
fix(transport): exit stdio server when the host closes stdin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import { createMcpServer, type McpDependencies } from "./presentation/mcp-tools.
 import {
   parseTransportType,
   startTransport,
+  registerParentExitShutdown,
 } from "./presentation/transport.js";
 import {
   parseVaultContextConfig,
@@ -278,6 +279,7 @@ async function main(): Promise<void> {
   };
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
+  registerParentExitShutdown(transportType, shutdown);
 
   // Periodic flush every 60 seconds
   setInterval(async () => {

--- a/src/presentation/transport.test.ts
+++ b/src/presentation/transport.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import type { AddressInfo } from "node:net";
 import type { Server as HttpServer } from "node:http";
+import { PassThrough } from "node:stream";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { parseTransportType, createSseApp } from "./transport.js";
+import {
+  parseTransportType,
+  createSseApp,
+  registerParentExitShutdown,
+} from "./transport.js";
 
 function createMockServerFactory() {
   // Replicate real Protocol.connect() behavior: it calls transport.start()
@@ -268,5 +273,57 @@ describe("createSseApp with auth", () => {
     );
     // 404 = auth passed, session not found (expected)
     expect(res.status).toBe(404);
+  });
+});
+
+describe("registerParentExitShutdown", () => {
+  async function settle(): Promise<void> {
+    for (let i = 0; i < 5; i++) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+  }
+
+  it("shuts down when the host closes stdin (EOF)", async () => {
+    const channel = new PassThrough();
+    const shutdown = vi.fn();
+
+    registerParentExitShutdown("stdio", shutdown, channel);
+    channel.end();
+    await settle();
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it("shuts down only once when both 'end' and 'close' fire", async () => {
+    const channel = new PassThrough();
+    const shutdown = vi.fn();
+
+    registerParentExitShutdown("stdio", shutdown, channel);
+    channel.end();
+    channel.destroy();
+    await settle();
+
+    expect(shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not register under sse, where the process outlives clients", async () => {
+    const channel = new PassThrough();
+    const shutdown = vi.fn();
+
+    registerParentExitShutdown("sse", shutdown, channel);
+    channel.end();
+    channel.destroy();
+    await settle();
+
+    expect(shutdown).not.toHaveBeenCalled();
+  });
+
+  it("resumes the stream so that EOF is actually delivered", () => {
+    const channel = new PassThrough();
+    const resume = vi.spyOn(channel, "resume");
+
+    registerParentExitShutdown("stdio", vi.fn(), channel);
+
+    expect(resume).toHaveBeenCalled();
   });
 });

--- a/src/presentation/transport.ts
+++ b/src/presentation/transport.ts
@@ -166,3 +166,51 @@ export async function startTransport(
     },
   };
 }
+
+/**
+ * Minimal shape of the channel that ties us to the MCP host.
+ *
+ * Structural on purpose: production passes `process.stdin`, tests pass a
+ * `PassThrough`.
+ */
+export interface ParentChannel {
+  on(event: "end" | "close", listener: () => void): unknown;
+  resume(): unknown;
+}
+
+/**
+ * Exit when the MCP host goes away.
+ *
+ * Under stdio the host owns our stdin. If it dies without sending SIGTERM —
+ * killed, crashed, or simply exited without reaping children — no signal ever
+ * reaches us, and the process would linger forever as an orphan holding the
+ * embedding model resident. EOF on stdin is the only reliable indication that
+ * the host is gone.
+ *
+ * Deliberately not registered for sse: there the process is a long-lived
+ * service that must outlive individual clients.
+ */
+export function registerParentExitShutdown(
+  type: TransportType,
+  shutdown: () => void | Promise<void>,
+  channel: ParentChannel = process.stdin,
+): void {
+  if (type !== "stdio") {
+    return;
+  }
+
+  let triggered = false;
+  const onParentGone = (): void => {
+    if (triggered) {
+      return;
+    }
+    triggered = true;
+    void shutdown();
+  };
+
+  channel.on("end", onParentGone);
+  channel.on("close", onParentGone);
+
+  // Without an active reader the stream stays paused and 'end' never fires.
+  channel.resume();
+}


### PR DESCRIPTION
Fixes #45.

## Problem

Under stdio the MCP host owns our stdin. When it dies without sending `SIGTERM` — killed, crashed, or simply exited without reaping children — no signal ever reaches the server, so it lingers forever as an orphan (`PPid=1`) holding the ONNX runtime and embedding model resident (250–500 MB per instance).

`StdioServerTransport` subscribes to stdin `'data'` and `'error'` only, so EOF goes unnoticed.

In our setup (an agent orchestrator spawning one worker per task) this accumulated ~17 orphans every 8 hours and took the host down twice in one day — once with swap thrashing, once with a full hang that needed a hard reset.

## Fix

`shutdown()` in `src/index.ts` was already correct and complete — it stops the indexer, closes the transport and persists the vector store. It simply was never reached when the parent vanished silently. This PR routes stdin EOF to that same function:

```ts
process.on("SIGINT", shutdown);
process.on("SIGTERM", shutdown);
registerParentExitShutdown(transportType, shutdown);
```

The helper lives in `src/presentation/transport.ts`, next to `TransportType` and `startTransport`:

- **Scoped to stdio.** Under sse the process is a long-lived service that must outlive individual clients, so nothing is registered there.
- **Guarded against re-entry.** `'end'` and `'close'` can both fire, and a signal may arrive concurrently; `shutdown()` runs at most once, so there is no double save of the vector store.
- **Calls `resume()`.** Without an active reader the stream stays paused and `'end'` would never fire. This runs after `startTransport()`, so the transport's own `'data'` listener is already attached and no input can be lost.
- **Structural `ParentChannel` type** so tests can inject a `PassThrough` instead of `process.stdin`.

## Tests

Written first, per CONTRIBUTING (RED → GREEN), co-located in `src/presentation/transport.test.ts`:

- shuts down when the host closes stdin (EOF)
- shuts down only once when both `'end'` and `'close'` fire
- does not register under sse
- resumes the stream so EOF is actually delivered

```
npm run lint   # tsc --noEmit, clean
npm run build  # clean
npm test       # 49 files, 636 tests passed
```

Also verified end-to-end against the built output: spawning `dist/index.js` with a pipe on stdin and letting the parent exit now leaves **no** surviving process, where previously it stayed alive indefinitely.

## Note on a red herring

Before finding this, we suspected the `npm exec` → `sh -c` → `node` wrapper chain created by `npx` was swallowing the signal. Installing the package globally so the binary is spawned directly changed nothing — the orphan rate stayed identical. Removing intermediate processes cannot help when no signal is sent in the first place.
